### PR TITLE
[002] `style` GitHub workflow runs only one version of Python

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -3,14 +3,10 @@ on: [push]
 jobs:
     style:
         runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                python-version: ['3.7', '3.8', '3.9']
-        steps:
         - uses: actions/checkout@v2
         - uses: actions/setup-python@v2
           with:
-              python-version: ${{ matrix.python-version }}
+              python-version: '3.8'
         - name: Install dependencies
           run: |
             python -m pip install --upgrade pip

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -5,8 +5,6 @@ jobs:
         runs-on: ubuntu-latest
         - uses: actions/checkout@v2
         - uses: actions/setup-python@v2
-          with:
-              python-version: '3.8'
         - name: Install dependencies
           run: |
             python -m pip install --upgrade pip

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -3,6 +3,7 @@ on: [push]
 jobs:
     style:
         runs-on: ubuntu-latest
+        steps:
         - uses: actions/checkout@v2
         - uses: actions/setup-python@v2
         - name: Install dependencies


### PR DESCRIPTION
It is not necessary to run the linting workflow against multiple version of Python.

Closes #2 