### PR TITLE
[004] Fix Python requirements in package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 
 [options]
 include_package_data = true
-python_requires = >= 3.6
+python_requires = >= 3.7
 packages = pod_store
 test_suite = tests
 setup_requires =


### PR DESCRIPTION
Requires >= 3.7, not 3.6.

Closes #4 