### PR TITLE
[022] Make `git` features optional

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,7 @@ def setup_test_store_data_and_downloads_path(request, store_podcasts_data):
     cleanup()
 
     os.makedirs(TEST_STORE_PATH)
+    os.makedirs(os.path.join(TEST_STORE_PATH, ".git"))  # register as "git enabled"
     os.makedirs(TEST_PODCAST_DOWNLOADS_PATH)
     with open(TEST_STORE_FILE_PATH, "w") as f:
         json.dump(store_podcasts_data, f, indent=2)

--- a/pod_store/__init__.py
+++ b/pod_store/__init__.py
@@ -33,6 +33,8 @@ try:
 except FileNotFoundError:
     GPG_ID = None
 
+STORE_GIT_REPO = os.path.join(STORE_PATH, ".git")
+
 PODCAST_DOWNLOADS_PATH = os.path.abspath(
     os.getenv("POD_STORE_PODCAST_DOWNLOADS_PATH", DEFAULT_PODCAST_DOWNLOADS_PATH)
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,6 +206,15 @@ def test_rm_aborts_if_not_confirmed(runner):
     assert result.exit_code == 1
 
 
+def test_git_add_and_commit_decorated_commands_work_if_git_is_not_set_up(
+    start_with_no_store, mocked_run_git_command, runner
+):
+    runner.invoke(cli, ["init", "--no-git"])
+    result = runner.invoke(cli, ["add", "not-git-tracked", "http://fake.url.com/rss"])
+    assert result.exit_code == 0
+    mocked_run_git_command.assert_not_called()
+
+
 def test_error_handling_gpg_command_error(mocker, runner):
     mocker.patch(
         "pod_store.__main__.run_git_command",


### PR DESCRIPTION
Previously any command decorated with the `git_add_and_commit` decorator would fail if no git repo had been established for the pod store. This fixes that bug and will not try to run git commands if no repo exists.