### PR TITLE
[026] Add Python 3.10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a very young/alpha-stage project. Use at your own risk, of course.
 
 ## Requirements
 
-Written for Linux environments running Python 3.7 and above. (Tested against 3.7, 3.8 and 3.9). May work on MacOS but probably does not work on Windows. Apart from Python library requirements, `pod-store` requires `git` (for syncing across devices) and `gpg` (for encryption).
+Written for Linux environments running Python 3.7 and above. May work on MacOS but probably does not work on Windows. Apart from Python library requirements, `pod-store` requires `git` (for syncing across devices) and `gpg` (for encryption).
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,14 @@ skip_gitignore = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py37,py38,py39
+envlist = py37,py38,py39,py310
 
 [gh-actions]
 python =
-    3.9: py39
-    3.8: py38
     3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
 deps = -rrequirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,11 +38,6 @@ install_requires =
     click == 8.0.1
     feedparser == 6.0.8
     requests == 2.26.0
-tests_require =
-    pytest == 6.2.5
-    pytest-env == 0.6.2
-    pytest-freezegun == 0.4.2
-    pytest-mock == 3.6.1
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 include_package_data = true


### PR DESCRIPTION
No change was necessary here, but add 3.10 to the `tox` tests and update docs/PyPI classifiers to reflect that this works using Python 3.10.

Closes #26