### PR TITLE
[048] Fix `git` command

### DIFF
--- a/pod_store/commands/decorators.py
+++ b/pod_store/commands/decorators.py
@@ -7,28 +7,9 @@ from typing import Any, Callable
 import click
 
 from .. import STORE_GIT_REPO
-from ..exc import (
-    EpisodeDoesNotExistError,
-    GPGCommandError,
-    NoEpisodesFoundError,
-    NoPodcastsFoundError,
-    PodcastDoesNotExistError,
-    PodcastExistsError,
-    ShellCommandError,
-    StoreExistsError,
-)
+from ..exc import ShellCommandError
 from ..util import run_git_command
-
-POD_STORE_EXCEPTIONS_AND_ERROR_MESSAGE_TEMPLATES = {
-    EpisodeDoesNotExistError: "Episode not found: {}.",
-    GPGCommandError: "Error encountered when running GPG commands: {}.",
-    NoEpisodesFoundError: "No episodes found. {}",
-    NoPodcastsFoundError: "No podcasts found. {}",
-    PodcastDoesNotExistError: "Podcast not found: {}.",
-    PodcastExistsError: "Podcast with title already exists: {}.",
-    ShellCommandError: "Error running shell command: {}.",
-    StoreExistsError: "Store already initialized: {}.",
-}
+from .helpers import display_pod_store_error_from_exception
 
 
 def catch_pod_store_errors(f: Callable) -> Callable:
@@ -41,14 +22,7 @@ def catch_pod_store_errors(f: Callable) -> Callable:
         try:
             return f(*args, **kwargs)
         except Exception as err:
-            try:
-                error_msg_template = POD_STORE_EXCEPTIONS_AND_ERROR_MESSAGE_TEMPLATES[
-                    err.__class__
-                ]
-                click.secho(error_msg_template.format(str(err)), fg="red")
-                raise click.Abort()
-            except KeyError:
-                raise err
+            display_pod_store_error_from_exception(err)
 
     return catch_pod_store_errors_inner
 

--- a/pod_store/commands/helpers.py
+++ b/pod_store/commands/helpers.py
@@ -4,15 +4,47 @@ from typing import Any, List, Optional
 import click
 
 from ..episodes import Episode
-from ..exc import NoEpisodesFoundError
+from ..exc import (
+    EpisodeDoesNotExistError,
+    GPGCommandError,
+    NoEpisodesFoundError,
+    NoPodcastsFoundError,
+    PodcastDoesNotExistError,
+    PodcastExistsError,
+    ShellCommandError,
+    StoreExistsError,
+)
 from ..podcasts import Podcast
 from ..store import Store
+
+
+POD_STORE_EXCEPTIONS_AND_ERROR_MESSAGE_TEMPLATES = {
+    EpisodeDoesNotExistError: "Episode not found: {}.",
+    GPGCommandError: "Error encountered when running GPG commands: {}.",
+    NoEpisodesFoundError: "No episodes found. {}",
+    NoPodcastsFoundError: "No podcasts found. {}",
+    PodcastDoesNotExistError: "Podcast not found: {}.",
+    PodcastExistsError: "Podcast with title already exists: {}.",
+    ShellCommandError: "Error running shell command: {}.",
+    StoreExistsError: "Store already initialized: {}.",
+}
 
 
 def abort_if_false(ctx: click.Context, _, value: Any) -> None:
     """Callback for aborting a Click command from within an argument or option."""
     if not value:
         ctx.abort()
+
+
+def display_pod_store_error_from_exception(exception: Exception):
+    try:
+        error_msg_template = POD_STORE_EXCEPTIONS_AND_ERROR_MESSAGE_TEMPLATES[
+            exception.__class__
+        ]
+        click.secho(error_msg_template.format(str(exception)), fg="red")
+        raise click.Abort()
+    except KeyError:
+        raise exception
 
 
 def get_episodes(

--- a/pod_store/commands/helpers.py
+++ b/pod_store/commands/helpers.py
@@ -17,7 +17,6 @@ from ..exc import (
 from ..podcasts import Podcast
 from ..store import Store
 
-
 POD_STORE_EXCEPTIONS_AND_ERROR_MESSAGE_TEMPLATES = {
     EpisodeDoesNotExistError: "Episode not found: {}.",
     GPGCommandError: "Error encountered when running GPG commands: {}.",


### PR DESCRIPTION
Defines a custom `click.Group` that intercepts invocations of `pod git <args>` and handles running the `git` command, displaying the output, and handling errors outside of the normal Click flow.

Closes #48 