### PR TITLE
[092] Bugfix: Detects when store has not been set up

### DIFF
--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -13,6 +13,7 @@ from .commands.commit_messages import (
 from .commands.decorators import (
     catch_pod_store_errors,
     git_add_and_commit,
+    require_store,
     save_store_changes,
 )
 from .commands.filtering import get_filter_from_command_arguments
@@ -110,6 +111,7 @@ def cli(ctx):
 @click.pass_context
 @click.argument("title")
 @click.argument("feed")
+@require_store
 @git_add_and_commit(message="Added podcast: {title!r}.", params=["title"])
 @save_store_changes
 @catch_pod_store_errors
@@ -145,6 +147,7 @@ def add(ctx: click.Context, title: str, feed: str):
     default=[],
     help="Supply tags to search for episodes with. Multiple tags can be provided.",
 )
+@require_store
 @git_add_and_commit(commit_message_builder=download_commit_message_builder)
 @save_store_changes
 @catch_pod_store_errors
@@ -180,6 +183,7 @@ def download(
     prompt="Are you sure you want to encrypt the pod store?",
     help="Skip the confirmation prompt.",
 )
+@require_store
 @git_add_and_commit(message="Encrypted the store.")
 def encrypt_store(ctx: click.Context, gpg_id: str):
     """Encrypt the pod store file with the provided gpg keys.
@@ -293,6 +297,7 @@ def init(git: bool, git_url: Optional[str], gpg_id: Optional[str]):
     help="(flag): Determines how much detail to provide in the listing. "
     "Defaults to `--not-verbose`.",
 )
+@require_store
 @catch_pod_store_errors
 def ls(
     ctx: click.Context,
@@ -335,6 +340,7 @@ def ls(
     help="(flag): Run this command in interactive mode to select which episodes to "
     "mark, or bulk mode to mark all episodes. Defaults to `--interactive`.",
 )
+@require_store
 @git_add_and_commit(commit_message_builder=tagger_commit_message_builder, tagger=marker)
 @save_store_changes
 @catch_pod_store_errors
@@ -366,6 +372,7 @@ def mark_as_new(ctx: click.Context, podcast: Optional[str], interactive: bool):
     help="(flag): Run this command in interactive mode to select which episodes to "
     "mark, or bulk mode to mark all episodes. Defaults to `--interactive`.",
 )
+@require_store
 @git_add_and_commit(
     commit_message_builder=tagger_commit_message_builder, tagger=unmarker
 )
@@ -385,6 +392,7 @@ def mark_as_old(ctx: click.Context, podcast: Optional[str], interactive: bool):
 @click.pass_context
 @click.argument("old")
 @click.argument("new")
+@require_store
 @git_add_and_commit(
     message="Renamed podcast: {old!r} -> {new!r}.", params=["old", "new"]
 )
@@ -422,6 +430,7 @@ def mv(ctx: click.Context, old: str, new: str):
     default=[],
     help="Filter podcasts by tag. Multiple tags can be provided.",
 )
+@require_store
 @git_add_and_commit(commit_message_builder=refresh_commit_message_builder)
 @save_store_changes
 @catch_pod_store_errors
@@ -453,6 +462,7 @@ def refresh(
     prompt="Are you sure you want to delete this podcast?",
     help="Skip confirmation prompt.",
 )
+@require_store
 @git_add_and_commit(message="Removed podcast: {title!r}.", params=["title"])
 @save_store_changes
 @catch_pod_store_errors
@@ -478,6 +488,7 @@ def rm(ctx: click.Context, title: str):
     "Note that this is the ID from the `ls --episodes --verbose` listing, not the "
     "episode number.",
 )
+@require_store
 @git_add_and_commit(commit_message_builder=tagger_commit_message_builder, tagger=tagger)
 @save_store_changes
 @catch_pod_store_errors
@@ -516,6 +527,7 @@ def tag(ctx: click.Context, podcast: str, tag: str, episode: Optional[str]):
     help="(flag): Run this command in interactive mode to select which episodes to "
     "tag, or bulk mode to tag all episodes in the group. Defaults to `--interactive`.",
 )
+@require_store
 @git_add_and_commit(commit_message_builder=tagger_commit_message_builder, tagger=tagger)
 @save_store_changes
 @catch_pod_store_errors
@@ -545,6 +557,7 @@ def tag_episodes(
     prompt="Are you sure you want to unencrypt the pod store?",
     help="Skip the confirmation prompt.",
 )
+@require_store
 @git_add_and_commit(message="Unencrypted the store.")
 def unencrypt_store(ctx: click.Context):
     """Unencrypt the pod store, saving the data in plaintext instead."""
@@ -565,6 +578,7 @@ def unencrypt_store(ctx: click.Context):
     "Note that this is the ID from the `ls --episodes --verbose` listing, not the "
     "episode number.",
 )
+@require_store
 @git_add_and_commit(
     commit_message_builder=tagger_commit_message_builder, tagger=untagger
 )
@@ -607,6 +621,7 @@ def untag(ctx: click.Context, podcast: str, tag: str, episode: Optional[str]):
     "untag, or bulk mode to untag all episodes in the group. Defaults to "
     "`--interactive`.",
 )
+@require_store
 @git_add_and_commit(
     commit_message_builder=tagger_commit_message_builder, tagger=untagger
 )

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -111,10 +111,10 @@ def cli(ctx):
 @click.pass_context
 @click.argument("title")
 @click.argument("feed")
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(message="Added podcast: {title!r}.", params=["title"])
 @save_store_changes
-@catch_pod_store_errors
 def add(ctx: click.Context, title: str, feed: str):
     """Add a podcast to the store.
 
@@ -147,10 +147,10 @@ def add(ctx: click.Context, title: str, feed: str):
     default=[],
     help="Supply tags to search for episodes with. Multiple tags can be provided.",
 )
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(commit_message_builder=download_commit_message_builder)
 @save_store_changes
-@catch_pod_store_errors
 def download(
     ctx: click.Context, podcast: Optional[str], is_tagged: bool, tag: List[str]
 ):
@@ -183,6 +183,7 @@ def download(
     prompt="Are you sure you want to encrypt the pod store?",
     help="Skip the confirmation prompt.",
 )
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(message="Encrypted the store.")
 def encrypt_store(ctx: click.Context, gpg_id: str):
@@ -297,8 +298,8 @@ def init(git: bool, git_url: Optional[str], gpg_id: Optional[str]):
     help="(flag): Determines how much detail to provide in the listing. "
     "Defaults to `--not-verbose`.",
 )
-@require_store
 @catch_pod_store_errors
+@require_store
 def ls(
     ctx: click.Context,
     new: bool,
@@ -340,10 +341,10 @@ def ls(
     help="(flag): Run this command in interactive mode to select which episodes to "
     "mark, or bulk mode to mark all episodes. Defaults to `--interactive`.",
 )
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(commit_message_builder=tagger_commit_message_builder, tagger=marker)
 @save_store_changes
-@catch_pod_store_errors
 def mark_as_new(ctx: click.Context, podcast: Optional[str], interactive: bool):
     """Add the `new` tag to a group of episodes.
 
@@ -372,12 +373,12 @@ def mark_as_new(ctx: click.Context, podcast: Optional[str], interactive: bool):
     help="(flag): Run this command in interactive mode to select which episodes to "
     "mark, or bulk mode to mark all episodes. Defaults to `--interactive`.",
 )
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(
     commit_message_builder=tagger_commit_message_builder, tagger=unmarker
 )
 @save_store_changes
-@catch_pod_store_errors
 def mark_as_old(ctx: click.Context, podcast: Optional[str], interactive: bool):
     """Remove the `new` tag from a group of episodes. Alias for the `untag` command."""
     store = ctx.obj
@@ -392,12 +393,12 @@ def mark_as_old(ctx: click.Context, podcast: Optional[str], interactive: bool):
 @click.pass_context
 @click.argument("old")
 @click.argument("new")
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(
     message="Renamed podcast: {old!r} -> {new!r}.", params=["old", "new"]
 )
 @save_store_changes
-@catch_pod_store_errors
 def mv(ctx: click.Context, old: str, new: str):
     """Rename a podcast in the store.
 
@@ -430,10 +431,10 @@ def mv(ctx: click.Context, old: str, new: str):
     default=[],
     help="Filter podcasts by tag. Multiple tags can be provided.",
 )
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(commit_message_builder=refresh_commit_message_builder)
 @save_store_changes
-@catch_pod_store_errors
 def refresh(
     ctx: click.Context, podcast: Optional[str], is_tagged: bool, tag: List[str]
 ):
@@ -462,10 +463,10 @@ def refresh(
     prompt="Are you sure you want to delete this podcast?",
     help="Skip confirmation prompt.",
 )
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(message="Removed podcast: {title!r}.", params=["title"])
 @save_store_changes
-@catch_pod_store_errors
 def rm(ctx: click.Context, title: str):
     """Remove a podcast from the store. This command will NOT delete the podcast
     episodes that have been downloaded.
@@ -488,10 +489,10 @@ def rm(ctx: click.Context, title: str):
     "Note that this is the ID from the `ls --episodes --verbose` listing, not the "
     "episode number.",
 )
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(commit_message_builder=tagger_commit_message_builder, tagger=tagger)
 @save_store_changes
-@catch_pod_store_errors
 def tag(ctx: click.Context, podcast: str, tag: str, episode: Optional[str]):
     """Tag a single podcast or episode with an arbitrary text tag. If the optional
     episode ID is provided, it will be tagged. Otherwise, the podcast itself will
@@ -527,10 +528,10 @@ def tag(ctx: click.Context, podcast: str, tag: str, episode: Optional[str]):
     help="(flag): Run this command in interactive mode to select which episodes to "
     "tag, or bulk mode to tag all episodes in the group. Defaults to `--interactive`.",
 )
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(commit_message_builder=tagger_commit_message_builder, tagger=tagger)
 @save_store_changes
-@catch_pod_store_errors
 def tag_episodes(
     ctx: click.Context, tag: str, podcast: Optional[str], interactive: bool
 ):
@@ -557,6 +558,7 @@ def tag_episodes(
     prompt="Are you sure you want to unencrypt the pod store?",
     help="Skip the confirmation prompt.",
 )
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(message="Unencrypted the store.")
 def unencrypt_store(ctx: click.Context):
@@ -578,12 +580,12 @@ def unencrypt_store(ctx: click.Context):
     "Note that this is the ID from the `ls --episodes --verbose` listing, not the "
     "episode number.",
 )
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(
     commit_message_builder=tagger_commit_message_builder, tagger=untagger
 )
 @save_store_changes
-@catch_pod_store_errors
 def untag(ctx: click.Context, podcast: str, tag: str, episode: Optional[str]):
     """Untag a single podcast or episode. If the optional episode ID is provided,
     it will be untagged. Otherwise, the podcast itself will be untagged.
@@ -621,12 +623,12 @@ def untag(ctx: click.Context, podcast: str, tag: str, episode: Optional[str]):
     "untag, or bulk mode to untag all episodes in the group. Defaults to "
     "`--interactive`.",
 )
+@catch_pod_store_errors
 @require_store
 @git_add_and_commit(
     commit_message_builder=tagger_commit_message_builder, tagger=untagger
 )
 @save_store_changes
-@catch_pod_store_errors
 def untag_episodes(
     ctx: click.Context, tag: str, podcast: Optional[str], interactive: bool
 ):

--- a/pod_store/commands/decorators.py
+++ b/pod_store/commands/decorators.py
@@ -7,7 +7,7 @@ from typing import Any, Callable
 import click
 
 from .. import STORE_GIT_REPO
-from ..exc import ShellCommandError
+from ..exc import ShellCommandError, StoreDoesNotExistError
 from ..util import run_git_command
 from .commit_messages import default_commit_message_builder
 from .helpers import display_pod_store_error_from_exception
@@ -70,6 +70,16 @@ def git_add_and_commit(
         return git_add_and_commit_inner
 
     return git_add_and_commit_wrapper
+
+
+def require_store(f: Callable) -> Callable:
+    @functools.wraps(f)
+    def require_store_inner(ctx: click.Context, *args, **kwargs):
+        if not ctx.obj:
+            raise StoreDoesNotExistError()
+        return f(ctx, *args, **kwargs)
+
+    return require_store_inner
 
 
 def save_store_changes(f: Callable) -> Callable:

--- a/pod_store/commands/helpers.py
+++ b/pod_store/commands/helpers.py
@@ -11,6 +11,7 @@ from ..exc import (
     PodcastDoesNotExistError,
     PodcastExistsError,
     ShellCommandError,
+    StoreDoesNotExistError,
     StoreExistsError,
 )
 
@@ -22,6 +23,9 @@ POD_STORE_EXCEPTIONS_AND_ERROR_MESSAGE_TEMPLATES = {
     PodcastDoesNotExistError: "Podcast not found: {}.",
     PodcastExistsError: "Podcast with title already exists: {}.",
     ShellCommandError: "Error running shell command: {}.",
+    StoreDoesNotExistError: (
+        "Store has not been set up. See the `init` command for set up instructions."
+    ),
     StoreExistsError: "Store already initialized: {}.",
 }
 

--- a/pod_store/exc.py
+++ b/pod_store/exc.py
@@ -36,5 +36,9 @@ class ShellCommandError(Exception):
     pass
 
 
+class StoreDoesNotExistError(Exception):
+    pass
+
+
 class StoreExistsError(Exception):
     pass

--- a/tests/test_command_helpers.py
+++ b/tests/test_command_helpers.py
@@ -15,6 +15,7 @@ from pod_store.exc import (
     PodcastDoesNotExistError,
     PodcastExistsError,
     ShellCommandError,
+    StoreDoesNotExistError,
     StoreExistsError,
 )
 
@@ -45,6 +46,10 @@ exceptions_and_error_messages = [
     (PodcastDoesNotExistError("zaza"), "Podcast not found: zaza."),
     (PodcastExistsError("zozo"), "Podcast with title already exists: zozo."),
     (ShellCommandError("xyz"), "Error running shell command: xyz."),
+    (
+        StoreDoesNotExistError(),
+        "Store has not been set up. See the `init` command for set up instructions.",
+    ),
     (StoreExistsError("/path"), "Store already initialized: /path."),
 ]
 


### PR DESCRIPTION
When a user runs a command that requires the pod store to be set up, but the store has not been set up, displays a helpful error message.

Introduces a `require_store` command decorator that looks for a Click context object and raises an exception if it has not been passed in.

Closes #92 