### PR TITLE
[089] Fallback for missing episode descriptions in `ls` command

### DIFF
--- a/pod_store/commands/listing.py
+++ b/pod_store/commands/listing.py
@@ -111,7 +111,7 @@ class EpisodeLister(Lister):
             created_at=e.created_at.isoformat(),
             updated_at=e.updated_at.isoformat(),
             downloaded_at_msg=downloaded_at_msg,
-            long_description=e.long_description,
+            long_description=e.long_description or "(no description)",
         )
 
     def _get_episode_listing(self, episode: Episode):

--- a/pod_store/commands/listing.py
+++ b/pod_store/commands/listing.py
@@ -10,7 +10,7 @@ from ..podcasts import Podcast
 from .filtering import Filter, get_filter_from_command_arguments
 
 EPISODE_LISTING_TEMPLATE = (
-    "[{episode_number}] {title}: {short_description_msg!r}{downloaded_msg}{tags_msg}"
+    "[{episode_number}] {title}: {short_description_msg}{downloaded_msg}{tags_msg}"
 )
 
 PODCAST_LISTING_TEMPLATE = "{title}{episodes_msg}{tags_msg}"
@@ -151,6 +151,9 @@ class EpisodeLister(Lister):
 
         This would break if the first word was too big to fit.
         """
+        if not short_description:
+            return "(no description)"
+
         terminal_width = get_terminal_size().columns
         short_description_length = terminal_width - len(
             EPISODE_LISTING_TEMPLATE.format(short_description_msg="", **template_kwargs)
@@ -162,7 +165,10 @@ class EpisodeLister(Lister):
             if len(new_short_description_msg) > short_description_length:
                 break
             short_description_msg = new_short_description_msg
-        return short_description_msg.rstrip(string.punctuation)
+        stripped_short_description_msg = short_description_msg.rstrip(
+            string.punctuation
+        )
+        return f"{stripped_short_description_msg!r}"
 
 
 class PodcastLister(Lister):

--- a/tests/test_commands_listing.py
+++ b/tests/test_commands_listing.py
@@ -78,12 +78,23 @@ goodbye world (longer description)""",
     ]
 
 
-def test_episode_lister_allows_empty_episode_short_description(store, episode_lister):
+def test_episode_lister_allows_empty_short_description(store, episode_lister):
     podcast = store.podcasts.get("greetings")
     episode = podcast.episodes.get("aaa")
     episode.short_description = ""
 
     assert "[0023] hello: (no description) -> new" in list(episode_lister.list())
+
+
+def test_episode_lister_allows_empty_long_description_in_verbose_mode(
+    store, episode_lister
+):
+    podcast = store.podcasts.get("farewell")
+    episode = podcast.episodes.get("111")
+    episode.long_description = ""
+
+    verbose_episode_listing = list(episode_lister.list(verbose=True))[1]
+    assert "(no description)" in verbose_episode_listing
 
 
 def test_episode_lister_list_raises_exception_when_no_episodes_found(store):

--- a/tests/test_commands_listing.py
+++ b/tests/test_commands_listing.py
@@ -78,6 +78,14 @@ goodbye world (longer description)""",
     ]
 
 
+def test_episode_lister_allows_empty_episode_short_description(store, episode_lister):
+    podcast = store.podcasts.get("greetings")
+    episode = podcast.episodes.get("aaa")
+    episode.short_description = ""
+
+    assert "[0023] hello: (no description) -> new" in list(episode_lister.list())
+
+
 def test_episode_lister_list_raises_exception_when_no_episodes_found(store):
     filter = EpisodeFilter(store=store, tags=["whoooooo"])
     episode_lister = EpisodeLister(filter=filter)


### PR DESCRIPTION
When a description is not provided, display placeholder text `(no description)` instead of failing.

Closes #89 