### PR TITLE
[079] Confirmation prompt for bulk tagging/untagging commands

### DIFF
--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -20,7 +20,13 @@ from .commands.decorators import (
 from .commands.filtering import get_filter_from_command_arguments
 from .commands.helpers import abort_if_false, display_pod_store_error_from_exception
 from .commands.listing import get_lister_from_command_arguments
-from .commands.tagging import marker, tagger, unmarker, untagger
+from .commands.tagging import (
+    prompt_for_confirmation_in_bulk_mode,
+    marker,
+    tagger,
+    unmarker,
+    untagger,
+)
 from .store import Store
 from .store_file_handlers import EncryptedStoreFileHandler, UnencryptedStoreFileHandler
 from .util import run_git_command
@@ -348,15 +354,27 @@ def ls(
     help="(flag): Run this command in interactive mode to select which episodes to "
     "mark, or bulk mode to mark all episodes. Defaults to `--interactive`.",
 )
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Skip confirmation prompt for bulk mode actions.",
+)
 @catch_pod_store_errors
 @require_store
 @git_add_and_commit(commit_message_builder=tagger_commit_message_builder, tagger=marker)
 @save_store_changes
-def mark_as_new(ctx: click.Context, podcast: Optional[str], interactive: bool):
+def mark_as_new(
+    ctx: click.Context,
+    podcast: Optional[str],
+    interactive: bool,
+    force: Optional[bool],
+):
     """Add the `new` tag to a group of episodes.
 
     See the `tag-episodes` command help for usage options.
     """
+    prompt_for_confirmation_in_bulk_mode(interactive=interactive, force=force)
     store = ctx.obj
     filter = get_filter_from_command_arguments(store=store, podcast_title=podcast)
 

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -14,6 +14,7 @@ from .commands.commit_messages import (
 from .commands.decorators import (
     catch_pod_store_errors,
     git_add_and_commit,
+    prompt_for_confirmation,
     require_store,
     save_store_changes,
 )
@@ -21,7 +22,6 @@ from .commands.filtering import get_filter_from_command_arguments
 from .commands.helpers import abort_if_false, display_pod_store_error_from_exception
 from .commands.listing import get_lister_from_command_arguments
 from .commands.tagging import (
-    prompt_for_confirmation_in_bulk_mode,
     marker,
     tagger,
     unmarker,
@@ -360,6 +360,7 @@ def ls(
     is_flag=True,
     help="Skip confirmation prompt for bulk mode actions.",
 )
+@prompt_for_confirmation(param="interactive", value=False, override="force")
 @catch_pod_store_errors
 @require_store
 @git_add_and_commit(commit_message_builder=tagger_commit_message_builder, tagger=marker)
@@ -374,7 +375,6 @@ def mark_as_new(
 
     See the `tag-episodes` command help for usage options.
     """
-    prompt_for_confirmation_in_bulk_mode(interactive=interactive, force=force)
     store = ctx.obj
     filter = get_filter_from_command_arguments(store=store, podcast_title=podcast)
 
@@ -398,13 +398,25 @@ def mark_as_new(
     help="(flag): Run this command in interactive mode to select which episodes to "
     "mark, or bulk mode to mark all episodes. Defaults to `--interactive`.",
 )
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Skip confirmation prompt for bulk mode actions.",
+)
+@prompt_for_confirmation(param="interactive", value=False, override="force")
 @catch_pod_store_errors
 @require_store
 @git_add_and_commit(
     commit_message_builder=tagger_commit_message_builder, tagger=unmarker
 )
 @save_store_changes
-def mark_as_old(ctx: click.Context, podcast: Optional[str], interactive: bool):
+def mark_as_old(
+    ctx: click.Context,
+    podcast: Optional[str],
+    interactive: bool,
+    force: Optional[bool],
+):
     """Remove the `new` tag from a group of episodes. Alias for the `untag` command."""
     store = ctx.obj
     filter = get_filter_from_command_arguments(store=store, podcast_title=podcast)
@@ -556,12 +568,23 @@ def tag(ctx: click.Context, podcast: str, tag: str, episode: Optional[str]):
     help="(flag): Run this command in interactive mode to select which episodes to "
     "tag, or bulk mode to tag all episodes in the group. Defaults to `--interactive`.",
 )
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Skip confirmation prompt for bulk mode actions.",
+)
+@prompt_for_confirmation(param="interactive", value=False, override="force")
 @catch_pod_store_errors
 @require_store
 @git_add_and_commit(commit_message_builder=tagger_commit_message_builder, tagger=tagger)
 @save_store_changes
 def tag_episodes(
-    ctx: click.Context, tag: str, podcast: Optional[str], interactive: bool
+    ctx: click.Context,
+    tag: str,
+    podcast: Optional[str],
+    interactive: bool,
+    force: Optional[bool],
 ):
     """Tag episodes in groups.
 
@@ -651,6 +674,13 @@ def untag(ctx: click.Context, podcast: str, tag: str, episode: Optional[str]):
     "untag, or bulk mode to untag all episodes in the group. Defaults to "
     "`--interactive`.",
 )
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Skip confirmation prompt for bulk mode actions.",
+)
+@prompt_for_confirmation(param="interactive", value=False, override="force")
 @catch_pod_store_errors
 @require_store
 @git_add_and_commit(
@@ -658,7 +688,11 @@ def untag(ctx: click.Context, podcast: str, tag: str, episode: Optional[str]):
 )
 @save_store_changes
 def untag_episodes(
-    ctx: click.Context, tag: str, podcast: Optional[str], interactive: bool
+    ctx: click.Context,
+    tag: str,
+    podcast: Optional[str],
+    interactive: bool,
+    force: Optional[bool],
 ):
     """Untag episodes in groups.
 

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -14,7 +14,7 @@ from .commands.commit_messages import (
 from .commands.decorators import (
     catch_pod_store_errors,
     git_add_and_commit,
-    prompt_for_confirmation,
+    conditional_confirmation_prompt,
     require_store,
     save_store_changes,
 )
@@ -360,7 +360,7 @@ def ls(
     is_flag=True,
     help="Skip confirmation prompt for bulk mode actions.",
 )
-@prompt_for_confirmation(param="interactive", value=False, override="force")
+@conditional_confirmation_prompt(param="interactive", value=False, override="force")
 @catch_pod_store_errors
 @require_store
 @git_add_and_commit(commit_message_builder=tagger_commit_message_builder, tagger=marker)
@@ -404,7 +404,7 @@ def mark_as_new(
     is_flag=True,
     help="Skip confirmation prompt for bulk mode actions.",
 )
-@prompt_for_confirmation(param="interactive", value=False, override="force")
+@conditional_confirmation_prompt(param="interactive", value=False, override="force")
 @catch_pod_store_errors
 @require_store
 @git_add_and_commit(
@@ -574,7 +574,7 @@ def tag(ctx: click.Context, podcast: str, tag: str, episode: Optional[str]):
     is_flag=True,
     help="Skip confirmation prompt for bulk mode actions.",
 )
-@prompt_for_confirmation(param="interactive", value=False, override="force")
+@conditional_confirmation_prompt(param="interactive", value=False, override="force")
 @catch_pod_store_errors
 @require_store
 @git_add_and_commit(commit_message_builder=tagger_commit_message_builder, tagger=tagger)
@@ -680,7 +680,7 @@ def untag(ctx: click.Context, podcast: str, tag: str, episode: Optional[str]):
     is_flag=True,
     help="Skip confirmation prompt for bulk mode actions.",
 )
-@prompt_for_confirmation(param="interactive", value=False, override="force")
+@conditional_confirmation_prompt(param="interactive", value=False, override="force")
 @catch_pod_store_errors
 @require_store
 @git_add_and_commit(

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -13,20 +13,15 @@ from .commands.commit_messages import (
 )
 from .commands.decorators import (
     catch_pod_store_errors,
-    git_add_and_commit,
     conditional_confirmation_prompt,
+    git_add_and_commit,
     require_store,
     save_store_changes,
 )
 from .commands.filtering import get_filter_from_command_arguments
 from .commands.helpers import abort_if_false, display_pod_store_error_from_exception
 from .commands.listing import get_lister_from_command_arguments
-from .commands.tagging import (
-    marker,
-    tagger,
-    unmarker,
-    untagger,
-)
+from .commands.tagging import marker, tagger, unmarker, untagger
 from .store import Store
 from .store_file_handlers import EncryptedStoreFileHandler, UnencryptedStoreFileHandler
 from .util import run_git_command

--- a/pod_store/commands/decorators.py
+++ b/pod_store/commands/decorators.py
@@ -2,7 +2,7 @@
 
 import functools
 import os
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import click
 
@@ -26,6 +26,22 @@ def catch_pod_store_errors(f: Callable) -> Callable:
             display_pod_store_error_from_exception(err)
 
     return catch_pod_store_errors_inner
+
+
+def prompt_for_confirmation(
+    param: str, value: Any, override: Optional[str] = None
+) -> Callable:
+    def prompt_for_confirmation_wrapper(f: Callable) -> Callable:
+        @functools.wraps(f)
+        def prompt_for_confirmation_inner(ctx, *args, **kwargs):
+            if ctx.params.get(param) == value and not ctx.params.get(override) is True:
+                if click.prompt("Confirm?", type=click.Choice(["y", "n"])) != "y":
+                    raise click.Abort()
+            return f(ctx, *args, **kwargs)
+
+        return prompt_for_confirmation_inner
+
+    return prompt_for_confirmation_wrapper
 
 
 def git_add_and_commit(

--- a/pod_store/commands/decorators.py
+++ b/pod_store/commands/decorators.py
@@ -72,7 +72,7 @@ def git_add_and_commit(
     return git_add_and_commit_wrapper
 
 
-def prompt_for_confirmation(
+def conditional_confirmation_prompt(
     param: str, value: Any, override: Optional[str] = None
 ) -> Callable:
     """Decorator for prompting the user to confirm the command if conditions are met.
@@ -84,7 +84,7 @@ def prompt_for_confirmation(
 
     For example:
 
-    @prompt_for_confirmation(param="hello", value="world", override="force")
+    @conditional_confirmation_prompt(param="hello", value="world", override="force")
     ...
 
     Would show a prompt if:
@@ -95,17 +95,17 @@ def prompt_for_confirmation(
     If the user does not confirm the action, the command is aborted.
     """
 
-    def prompt_for_confirmation_wrapper(f: Callable) -> Callable:
+    def conditional_confirmation_prompt_wrapper(f: Callable) -> Callable:
         @functools.wraps(f)
-        def prompt_for_confirmation_inner(ctx, *args, **kwargs) -> Any:
+        def conditional_confirmation_prompt_inner(ctx, *args, **kwargs) -> Any:
             if ctx.params.get(param) == value and not ctx.params.get(override) is True:
                 if click.prompt("Confirm?", type=click.Choice(["y", "n"])) != "y":
                     raise click.Abort()
             return f(ctx, *args, **kwargs)
 
-        return prompt_for_confirmation_inner
+        return conditional_confirmation_prompt_inner
 
-    return prompt_for_confirmation_wrapper
+    return conditional_confirmation_prompt_wrapper
 
 
 def require_store(f: Callable) -> Callable:

--- a/pod_store/commands/tagging.py
+++ b/pod_store/commands/tagging.py
@@ -216,7 +216,9 @@ class Untagger(BaseTagger):
         item.untag(tag)
 
 
-def conditional_confirmation_prompt_in_bulk_mode(interactive: bool, force: bool) -> None:
+def conditional_confirmation_prompt_in_bulk_mode(
+    interactive: bool, force: bool
+) -> None:
     bulk_mode = not interactive
     if bulk_mode and not force:
         if not click.prompt("Confirm? [y/n]") == "y":

--- a/pod_store/commands/tagging.py
+++ b/pod_store/commands/tagging.py
@@ -216,7 +216,7 @@ class Untagger(BaseTagger):
         item.untag(tag)
 
 
-def prompt_for_confirmation_in_bulk_mode(interactive: bool, force: bool) -> None:
+def conditional_confirmation_prompt_in_bulk_mode(interactive: bool, force: bool) -> None:
     bulk_mode = not interactive
     if bulk_mode and not force:
         if not click.prompt("Confirm? [y/n]") == "y":

--- a/pod_store/commands/tagging.py
+++ b/pod_store/commands/tagging.py
@@ -216,15 +216,6 @@ class Untagger(BaseTagger):
         item.untag(tag)
 
 
-def conditional_confirmation_prompt_in_bulk_mode(
-    interactive: bool, force: bool
-) -> None:
-    bulk_mode = not interactive
-    if bulk_mode and not force:
-        if not click.prompt("Confirm? [y/n]") == "y":
-            raise click.Abort()
-
-
 # These instances of the tagger classes are used to customize the language used in
 # displaying output to the user. The marker/unmarker objects also work with a default
 # tag.

--- a/pod_store/commands/tagging.py
+++ b/pod_store/commands/tagging.py
@@ -216,6 +216,13 @@ class Untagger(BaseTagger):
         item.untag(tag)
 
 
+def prompt_for_confirmation_in_bulk_mode(interactive: bool, force: bool) -> None:
+    bulk_mode = not interactive
+    if bulk_mode and not force:
+        if not click.prompt("Confirm? [y/n]") == "y":
+            raise click.Abort()
+
+
 # These instances of the tagger classes are used to customize the language used in
 # displaying output to the user. The marker/unmarker objects also work with a default
 # tag.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -202,14 +202,20 @@ def test_ls_podcast_episodes(runner):
 
 
 def test_mark_as_new_all_episodes_bulk_mode(runner):
-    result = runner.invoke(cli, ["mark-as-new", "--bulk"])
+    result = runner.invoke(cli, ["mark-as-new", "-f", "--bulk"])
     assert result.exit_code == 0
     assert "Marked as 'new': farewell" in result.output
     assert "Marked as 'new': greetings" in result.output
 
 
+def test_mark_as_new_bulk_mode_does_not_run_if_not_confirmed(runner):
+    result = runner.invoke(cli, ["mark-as-new", "--bulk"], input="n\n")
+    assert result.exit_code == 1
+    assert "Marked" not in result.output
+
+
 def test_mark_as_new_for_single_podcast(runner):
-    result = runner.invoke(cli, ["mark-as-new", "-p", "farewell", "--bulk"])
+    result = runner.invoke(cli, ["mark-as-new", "-f", "-p", "farewell", "--bulk"])
     assert result.exit_code == 0
     assert "Marked as 'new': farewell" in result.output
     assert "Marked as 'new': greetings" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -202,20 +202,14 @@ def test_ls_podcast_episodes(runner):
 
 
 def test_mark_as_new_all_episodes_bulk_mode(runner):
-    result = runner.invoke(cli, ["mark-as-new", "-f", "--bulk"])
+    result = runner.invoke(cli, ["mark-as-new", "--force", "--bulk"])
     assert result.exit_code == 0
     assert "Marked as 'new': farewell" in result.output
     assert "Marked as 'new': greetings" in result.output
 
 
-def test_mark_as_new_bulk_mode_does_not_run_if_not_confirmed(runner):
-    result = runner.invoke(cli, ["mark-as-new", "--bulk"], input="n\n")
-    assert result.exit_code == 1
-    assert "Marked" not in result.output
-
-
 def test_mark_as_new_for_single_podcast(runner):
-    result = runner.invoke(cli, ["mark-as-new", "-f", "-p", "farewell", "--bulk"])
+    result = runner.invoke(cli, ["mark-as-new", "--force", "--bulk", "-p", "farewell"])
     assert result.exit_code == 0
     assert "Marked as 'new': farewell" in result.output
     assert "Marked as 'new': greetings" not in result.output
@@ -230,14 +224,14 @@ def test_mark_as_new_interactive_mode(runner):
 
 
 def test_mark_as_old_all_episodes_bulk_mode(runner):
-    result = runner.invoke(cli, ["mark-as-old", "--bulk"])
+    result = runner.invoke(cli, ["mark-as-old", "--force", "--bulk"])
     assert result.exit_code == 0
     assert "Unmarked as 'new': farewell" in result.output
     assert "Unmarked as 'new': greetings" in result.output
 
 
 def test_mark_as_old_for_single_podcast(runner):
-    result = runner.invoke(cli, ["mark-as-old", "-p", "farewell", "--bulk"])
+    result = runner.invoke(cli, ["mark-as-old", "--force", "--bulk", "-p", "farewell"])
     assert result.exit_code == 0
     assert "Unmarked as 'new': farewell" in result.output
     assert "Unmarked as 'new': greetings" not in result.output
@@ -311,14 +305,16 @@ def test_tag_a_pocast_episode(runner):
 
 
 def test_tag_episodes_all_episodes_bulk_mode(runner):
-    result = runner.invoke(cli, ["tag-episodes", "foo", "--bulk"])
+    result = runner.invoke(cli, ["tag-episodes", "foo", "--force", "--bulk"])
     assert result.exit_code == 0
     assert "Tagged as 'foo': farewell" in result.output
     assert "Tagged as 'foo': greetings" in result.output
 
 
 def test_tag_episodes_for_single_podcast(runner):
-    result = runner.invoke(cli, ["tag-episodes", "zozo", "-p", "greetings", "--bulk"])
+    result = runner.invoke(
+        cli, ["tag-episodes", "zozo", "--force", "--bulk", "-p", "greetings"]
+    )
     assert result.exit_code == 0
     assert "Tagged as 'zozo': farewell" not in result.output
     assert "Tagged as 'zozo': greetings" in result.output
@@ -359,14 +355,16 @@ def test_untag_single_pocast_episode(runner):
 
 
 def test_untag_episodes_all_episodes_bulk_mode(runner):
-    result = runner.invoke(cli, ["untag-episodes", "foo", "--bulk"])
+    result = runner.invoke(cli, ["untag-episodes", "foo", "--force", "--bulk"])
     assert result.exit_code == 0
     assert "Untagged as 'foo': farewell" in result.output
     assert "Untagged as 'foo': greetings" in result.output
 
 
 def test_untag_episodes_for_single_podcast(runner):
-    result = runner.invoke(cli, ["untag-episodes", "foo", "-p", "greetings", "--bulk"])
+    result = runner.invoke(
+        cli, ["untag-episodes", "foo", "--force", "--bulk", "-p", "greetings"]
+    )
     assert result.exit_code == 0
     assert "Untagged as 'foo': farewell" not in result.output
     assert "Untagged as 'foo': greetings" in result.output

--- a/tests/test_commands_decorators.py
+++ b/tests/test_commands_decorators.py
@@ -8,7 +8,7 @@ import pytest
 from pod_store.commands.decorators import (
     catch_pod_store_errors,
     git_add_and_commit,
-    prompt_for_confirmation,
+    conditional_confirmation_prompt,
     require_store,
     save_store_changes,
 )
@@ -51,8 +51,8 @@ def test_git_add_and_commit_adds_changes_and_builds_commit_message(mocker):
     )
 
 
-def test_prompt_for_confirmation_param_does_not_match_value():
-    @prompt_for_confirmation(param="hello", value=False)
+def test_conditional_confirmation_prompt_param_does_not_match_value():
+    @conditional_confirmation_prompt(param="hello", value=False)
     def no_match(ctx):
         return True
 
@@ -60,8 +60,8 @@ def test_prompt_for_confirmation_param_does_not_match_value():
     assert no_match(ctx) is True
 
 
-def test_prompt_for_confirmation_param_matches_value_but_override_flag_is_set():
-    @prompt_for_confirmation(param="hello", value=True, override="flagged")
+def test_conditional_confirmation_prompt_param_matches_value_but_override_flag_is_set():
+    @conditional_confirmation_prompt(param="hello", value=True, override="flagged")
     def flagged(ctx):
         return True
 
@@ -69,12 +69,12 @@ def test_prompt_for_confirmation_param_matches_value_but_override_flag_is_set():
     assert flagged(ctx) is True
 
 
-def test_prompt_for_confirmation_param_matches_override_not_set_prompt_confirmed(
+def test_conditional_confirmation_prompt_param_matches_override_not_set_prompt_confirmed(
     mocker,
 ):
     mocker.patch("click.prompt", return_value="y")
 
-    @prompt_for_confirmation(param="hello", value=True, override="flagged")
+    @conditional_confirmation_prompt(param="hello", value=True, override="flagged")
     def prompt_passed(ctx):
         return True
 
@@ -82,12 +82,12 @@ def test_prompt_for_confirmation_param_matches_override_not_set_prompt_confirmed
     assert prompt_passed(ctx) is True
 
 
-def test_prompt_for_confirmation_param_matches_override_not_set_prompt_not_confirmed(
+def test_conditional_confirmation_prompt_param_matches_override_not_set_prompt_not_confirmed(
     mocker,
 ):
     mocker.patch("click.prompt", return_value="n")
 
-    @prompt_for_confirmation(param="hello", value=True, override="flagged")
+    @conditional_confirmation_prompt(param="hello", value=True, override="flagged")
     def prompt_failed(ctx):
         return True
 

--- a/tests/test_commands_decorators.py
+++ b/tests/test_commands_decorators.py
@@ -7,8 +7,8 @@ import pytest
 
 from pod_store.commands.decorators import (
     catch_pod_store_errors,
-    git_add_and_commit,
     conditional_confirmation_prompt,
+    git_add_and_commit,
     require_store,
     save_store_changes,
 )

--- a/tests/test_commands_decorators.py
+++ b/tests/test_commands_decorators.py
@@ -69,29 +69,29 @@ def test_conditional_confirmation_prompt_param_matches_value_but_override_flag_i
     assert flagged(ctx) is True
 
 
-def test_conditional_confirmation_prompt_param_matches_override_not_set_prompt_confirmed(
+def test_conditional_confirmation_prompt_param_matches_no_override_prompt_confirmed(
     mocker,
 ):
     mocker.patch("click.prompt", return_value="y")
 
-    @conditional_confirmation_prompt(param="hello", value=True, override="flagged")
+    @conditional_confirmation_prompt(param="hello", value=True)
     def prompt_passed(ctx):
         return True
 
-    ctx = fake_ctx(obj=None, params={"hello": True, "flagged": False})
+    ctx = fake_ctx(obj=None, params={"hello": True})
     assert prompt_passed(ctx) is True
 
 
-def test_conditional_confirmation_prompt_param_matches_override_not_set_prompt_not_confirmed(
+def test_conditional_confirmation_prompt_param_no_override_prompt_not_confirmed(
     mocker,
 ):
     mocker.patch("click.prompt", return_value="n")
 
-    @conditional_confirmation_prompt(param="hello", value=True, override="flagged")
+    @conditional_confirmation_prompt(param="hello", value=True)
     def prompt_failed(ctx):
         return True
 
-    ctx = fake_ctx(obj=None, params={"hello": True, "flagged": False})
+    ctx = fake_ctx(obj=None, params={"hello": True})
     with pytest.raises(click.Abort):
         prompt_failed(ctx)
 


### PR DESCRIPTION
Prompts the user to confirm when they are running a command that will prompt a bulk tagging action.

Introduces a command decorator that displays a confirmation prompt when a given parameter is set to a given value, and an override flag parameter is not set to `True`.

Closes #79 