### PR TITLE
[108] Improve tagging CLI

### DIFF
--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -391,17 +391,13 @@ def mark_as_new(
     interactive: bool,
     force: Optional[bool],
 ):
-    """Add the `new` tag to a group of episodes.
-
-    See the `tag-episodes` command help for usage options.
-    """
+    """Add the `new` tag to a group of episodes."""
     store = ctx.obj
     tagger = get_tagger_from_command_arguments(
         store=store,
-        podcast_title=podcast,
+        tags=["new"],
         tag_episodes=True,
-        is_untagger=True,
-        tag="new",
+        podcast_title=podcast,
         action="mark",
     )
 
@@ -445,14 +441,14 @@ def mark_as_old(
     interactive: bool,
     force: Optional[bool],
 ):
-    """Remove the `new` tag from a group of episodes. Alias for the `untag` command."""
+    """Remove the `new` tag from a group of episodes."""
     store = ctx.obj
     tagger = get_tagger_from_command_arguments(
         store=store,
-        podcast_title=podcast,
+        tags=["new"],
         tag_episodes=True,
-        is_untagger=False,
-        tag="new",
+        podcast_title=podcast,
+        is_untagger=True,
         action="unmark",
     )
 

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -141,14 +141,15 @@ def add(ctx: click.Context, title: str, feed: str):
     help="(podcast title): Download only episodes for the specified podcast.",
 )
 @click.option(
-    "--is-tagged/--not-tagged",
-    default=True,
-    help="(flag): Search for episodes with or without the supplied tags. "
-    "Defaults to `is-tagged`. Has no effect if no tags are indicated.",
+    "--tagged",
+    "-t",
+    multiple=True,
+    default=[],
+    help="Supply tags to search for episodes with. Multiple tags can be provided.",
 )
 @click.option(
-    "--tag",
-    "-t",
+    "--untagged",
+    "-u",
     multiple=True,
     default=[],
     help="Supply tags to search for episodes with. Multiple tags can be provided.",
@@ -161,7 +162,10 @@ def add(ctx: click.Context, title: str, feed: str):
 )
 @save_store_changes
 def download(
-    ctx: click.Context, podcast: Optional[str], is_tagged: bool, tag: List[str]
+    ctx: click.Context,
+    podcast: Optional[str],
+    tagged: List[str],
+    untagged: List[str],
 ):
     """Download podcast episodes."""
     store = ctx.obj
@@ -169,10 +173,10 @@ def download(
     filter = get_filter_from_command_arguments(
         store=store,
         new_episodes=True,
-        filter_episodes=True,
+        filter_for_episodes=True,
         podcast_title=podcast,
-        tags=tag,
-        filter_untagged_items=not is_tagged,
+        tagged=tagged,
+        untagged=untagged,
     )
 
     for ep in filter.items:
@@ -302,14 +306,15 @@ def init(git: bool, git_url: Optional[str], gpg_id: Optional[str]):
     help="(podcast title): List only episodes for the specified podcast.",
 )
 @click.option(
-    "--list-tagged/--not-tagged",
-    default=True,
-    help="(flag): Search for episodes with or without the supplied tags. "
-    "Defaults to `--list-tagged`. Has no effect if no tags are indicated.",
+    "--tagged",
+    "-t",
+    multiple=True,
+    default=[],
+    help="Supply tags to search for episodes with. Multiple tags can be provided.",
 )
 @click.option(
-    "--tag",
-    "-t",
+    "--untagged",
+    "-u",
     multiple=True,
     default=[],
     help="Supply tags to search for episodes with. Multiple tags can be provided.",
@@ -327,8 +332,8 @@ def ls(
     new: bool,
     episodes: bool,
     podcast: Optional[str],
-    list_tagged: bool,
-    tag: List[str],
+    tagged: Optional[List[str]],
+    untagged: Optional[List[str]],
     verbose: bool,
 ):
     """List data from the store.
@@ -342,8 +347,8 @@ def ls(
         new_episodes=new,
         list_episodes=episodes,
         podcast_title=podcast,
-        list_untagged_items=not list_tagged,
-        tags=tag,
+        tagged=tagged,
+        untagged=untagged,
     )
     for msg in lister.list(verbose=verbose):
         click.echo(msg)
@@ -484,14 +489,15 @@ def mv(ctx: click.Context, old: str, new: str):
     help="(podcast title): Refresh only the specified podcast.",
 )
 @click.option(
-    "--is-tagged/--not-tagged",
-    default=True,
-    help="(flag): Search for podcasts with or without the tags supplied. "
-    "Defaults to `--is-tagged`. Has no effect if no tags are indicated.",
+    "--tagged",
+    "-t",
+    multiple=True,
+    default=[],
+    help="Filter podcasts by tag. Multiple tags can be provided.",
 )
 @click.option(
-    "--tag",
-    "-t",
+    "--untagged",
+    "-u",
     multiple=True,
     default=[],
     help="Filter podcasts by tag. Multiple tags can be provided.",
@@ -504,16 +510,19 @@ def mv(ctx: click.Context, old: str, new: str):
 )
 @save_store_changes
 def refresh(
-    ctx: click.Context, podcast: Optional[str], is_tagged: bool, tag: List[str]
+    ctx: click.Context,
+    podcast: Optional[str],
+    tagged: Optional[List[str]],
+    untagged: Optional[List[str]],
 ):
     """Refresh podcast episode data from the RSS feed."""
     store = ctx.obj
     filter = get_filter_from_command_arguments(
         store=store,
-        filter_episodes=False,
+        filter_for_episodes=False,
         podcast_title=podcast,
-        tags=tag,
-        filter_untagged_items=not is_tagged,
+        tagged=tagged,
+        untagged=untagged,
     )
     for podcast in filter.items:
         click.echo(f"Refreshing {podcast.title}")

--- a/pod_store/commands/filtering.py
+++ b/pod_store/commands/filtering.py
@@ -171,23 +171,25 @@ class PodcastFilter(Filter):
 def get_filter_from_command_arguments(
     store: Store,
     new_episodes: bool = None,
-    filter_episodes: bool = False,
+    filter_for_episodes: bool = False,
     podcast_title: Optional[str] = None,
-    tags: Optional[List] = None,
-    filter_untagged_items: bool = False,
+    tagged: Optional[List] = None,
+    untagged: Optional[List] = None,
     **filters,
 ) -> Union[EpisodeFilter, PodcastFilter]:
     """Helper method for building a filter based on common CLI command arguments."""
-    tags = tags or []
-    if filter_episodes is None:
-        filter_episodes = filter_episodes or podcast_title
+    tagged = tagged or []
+    untagged = untagged or []
+    if filter_for_episodes is None:
+        filter_for_episodes = filter_for_episodes or podcast_title
 
-    if filter_untagged_items:
-        filters = {**{t: False for t in tags}, **filters}
-    else:
-        filters = {**{t: True for t in tags}, **filters}
+    filters = {
+        **{t: True for t in tagged},
+        **{u: False for u in untagged},
+        **filters,
+    }
 
-    if filter_episodes:
+    if filter_for_episodes:
         filter_cls = EpisodeFilter
     else:
         filter_cls = PodcastFilter

--- a/pod_store/commands/listing.py
+++ b/pod_store/commands/listing.py
@@ -230,7 +230,6 @@ class PodcastLister(Lister):
 
 
 def get_lister_from_command_arguments(
-    list_untagged_items: bool = False,
     list_episodes: bool = False,
     podcast_title: Optional[str] = None,
     **filters,
@@ -241,8 +240,7 @@ def get_lister_from_command_arguments(
     Builds a filter that the lister will use.
     """
     filter = get_filter_from_command_arguments(
-        filter_untagged_items=list_untagged_items,
-        filter_episodes=list_episodes,
+        filter_for_episodes=list_episodes,
         podcast_title=podcast_title,
         **filters,
     )

--- a/pod_store/commands/tagging.py
+++ b/pod_store/commands/tagging.py
@@ -140,7 +140,8 @@ class Untagger(BaseTagger):
 
 def get_tagger_from_command_arguments(
     store: Store,
-    tag: str,
+    tag: str = "",
+    tags: List[str] = [],
     tag_episodes: bool = False,
     is_untagger: bool = False,
     podcast_title: Optional[str] = None,
@@ -152,8 +153,8 @@ def get_tagger_from_command_arguments(
 
     Builds a filter for the tagger to use.
     """
+    tags = tags or [tag]
     filters = filters or {}
-    tags = [tag]
 
     if is_untagger:
         filter_tagged = tags

--- a/pod_store/commands/tagging.py
+++ b/pod_store/commands/tagging.py
@@ -140,11 +140,10 @@ class Untagger(BaseTagger):
 
 def get_tagger_from_command_arguments(
     store: Store,
-    tag: str = "",
-    tags: List[str] = [],
+    tags: List[str],
     tag_episodes: bool = False,
-    is_untagger: bool = False,
     podcast_title: Optional[str] = None,
+    is_untagger: bool = False,
     filters: Optional[dict] = None,
     **tagger_kwargs,
 ) -> Tagger:
@@ -153,7 +152,6 @@ def get_tagger_from_command_arguments(
 
     Builds a filter for the tagger to use.
     """
-    tags = tags or [tag]
     filters = filters or {}
 
     if is_untagger:

--- a/pod_store/commands/tagging.py
+++ b/pod_store/commands/tagging.py
@@ -154,11 +154,19 @@ def get_tagger_from_command_arguments(
     """
     filters = filters or {}
     tags = [tag]
+
+    if is_untagger:
+        filter_tagged = tags
+        filter_untagged = []
+    else:
+        filter_tagged = []
+        filter_untagged = tags
+
     filter = get_filter_from_command_arguments(
         store=store,
-        filter_untagged_items=not is_untagger,
-        tags=tags,
-        filter_episodes=tag_episodes,
+        tagged=filter_tagged,
+        untagged=filter_untagged,
+        filter_for_episodes=tag_episodes,
         podcast_title=podcast_title,
         **filters,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,7 +59,7 @@ def test_download_new_episodes_with_tag(runner):
 
 
 def test_download_new_episodes_without_tag(runner):
-    result = runner.invoke(cli, ["download", "--not-tagged", "-t", "bar"])
+    result = runner.invoke(cli, ["download", "-u", "bar"])
     assert result.exit_code == 0
     assert result.output == f"Downloading: {TEST_EPISODE_DOWNLOAD_PATH}.\n\n"
 
@@ -154,7 +154,7 @@ def test_ls_podcasts_with_tag(runner):
 
 
 def test_ls_podcasts_without_tag(runner):
-    result = runner.invoke(cli, ["ls", "--all", "--not-tagged", "-t", "hello"])
+    result = runner.invoke(cli, ["ls", "--all", "-u", "hello"])
     assert result.exit_code == 0
     assert "farewell" in result.output
     assert "greetings" not in result.output
@@ -187,9 +187,7 @@ def test_ls_episodes_with_tag(runner):
 
 
 def test_ls_without_tag(runner):
-    result = runner.invoke(
-        cli, ["ls", "--episodes", "--all", "--not-tagged", "-t", "foo"]
-    )
+    result = runner.invoke(cli, ["ls", "--episodes", "--all", "-u", "foo"])
     assert result.exit_code == 0
     assert "0001" in result.output
     assert "0002" not in result.output
@@ -272,7 +270,7 @@ def test_refresh_podcasts_with_tag(runner):
 
 
 def test_refresh_podcasts_without_tag(runner):
-    result = runner.invoke(cli, ["refresh", "--not-tagged", "-t", "hello"])
+    result = runner.invoke(cli, ["refresh", "-u", "hello"])
     assert result.exit_code == 0
     assert result.output == "Refreshing farewell\nRefreshing other\n"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -292,19 +292,21 @@ def test_rm_aborts_if_not_confirmed(runner):
 
 
 def test_tag_a_podcast(runner):
-    result = runner.invoke(cli, ["tag", "greetings", "foobar"])
+    result = runner.invoke(cli, ["tag", "greetings", "-t", "foobar"])
     assert result.exit_code == 0
     assert result.output == "Tagged as foobar: greetings.\n"
 
 
 def test_tag_a_pocast_episode(runner):
-    result = runner.invoke(cli, ["tag", "greetings", "--episode", "aaa", "foobar"])
+    result = runner.invoke(
+        cli, ["tag", "greetings", "--episode", "aaa", "-t", "foobar"]
+    )
     assert result.exit_code == 0
     assert result.output == "Tagged as foobar: greetings -> [0023] hello.\n"
 
 
 def test_tag_episodes_all_episodes_bulk_mode(runner):
-    result = runner.invoke(cli, ["tag-episodes", "foo", "--force", "--bulk"])
+    result = runner.invoke(cli, ["tag-episodes", "-t", "foo", "--force", "--bulk"])
     assert result.exit_code == 0
     assert "Tagged as foo: farewell" in result.output
     assert "Tagged as foo: greetings" in result.output
@@ -312,7 +314,7 @@ def test_tag_episodes_all_episodes_bulk_mode(runner):
 
 def test_tag_episodes_for_single_podcast(runner):
     result = runner.invoke(
-        cli, ["tag-episodes", "zozo", "--force", "--bulk", "-p", "greetings"]
+        cli, ["tag-episodes", "-t", "zozo", "--force", "--bulk", "-p", "greetings"]
     )
     assert result.exit_code == 0
     assert "Tagged as zozo: farewell" not in result.output
@@ -321,7 +323,7 @@ def test_tag_episodes_for_single_podcast(runner):
 
 def test_tag_episodes_interactive_mode(runner):
     result = runner.invoke(
-        cli, ["tag-episodes", "foo", "--interactive"], input="n\ny\n"
+        cli, ["tag-episodes", "-t", "foo", "--interactive"], input="n\ny\n"
     )
     assert result.exit_code == 0
     assert "Tagged as foo: farewell" not in result.output
@@ -342,19 +344,19 @@ def test_unencrypt_aborts_if_not_confirmed(runner):
 
 
 def test_untag_a_podcast(runner):
-    result = runner.invoke(cli, ["untag", "greetings", "hello"])
+    result = runner.invoke(cli, ["untag", "greetings", "-t", "hello"])
     assert result.exit_code == 0
     assert result.output == "Untagged as hello: greetings.\n"
 
 
 def test_untag_single_pocast_episode(runner):
-    result = runner.invoke(cli, ["untag", "greetings", "--episode", "aaa", "new"])
+    result = runner.invoke(cli, ["untag", "greetings", "--episode", "aaa", "-t", "new"])
     assert result.exit_code == 0
     assert result.output == "Untagged as new: greetings -> [0023] hello.\n"
 
 
 def test_untag_episodes_all_episodes_bulk_mode(runner):
-    result = runner.invoke(cli, ["untag-episodes", "foo", "--force", "--bulk"])
+    result = runner.invoke(cli, ["untag-episodes", "-t", "foo", "--force", "--bulk"])
     assert result.exit_code == 0
     assert "Untagged as foo: farewell" in result.output
     assert "Untagged as foo: greetings" in result.output
@@ -362,7 +364,7 @@ def test_untag_episodes_all_episodes_bulk_mode(runner):
 
 def test_untag_episodes_for_single_podcast(runner):
     result = runner.invoke(
-        cli, ["untag-episodes", "foo", "--force", "--bulk", "-p", "greetings"]
+        cli, ["untag-episodes", "-t", "foo", "--force", "--bulk", "-p", "greetings"]
     )
     assert result.exit_code == 0
     assert "Untagged as foo: farewell" not in result.output
@@ -371,7 +373,7 @@ def test_untag_episodes_for_single_podcast(runner):
 
 def test_untag_episodes_interactive_mode(runner):
     result = runner.invoke(
-        cli, ["untag-episodes", "foo", "--interactive"], input="n\ny\nn\n"
+        cli, ["untag-episodes", "-t", "foo", "--interactive"], input="n\ny\nn\n"
     )
     assert result.exit_code == 0
     assert "Untagged as foo: farewell" not in result.output


### PR DESCRIPTION
Enables filtering by both presence and absence of tags in commands, and allows adding/removing multiple tags at once in the tagging/untagging commands.

Closes #108 