### PR TITLE
[090] Set podcasts to `inactive`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Refresh episode data for all podcasts from their RSS feeds, or just a specific p
     pod refresh
     pod refresh -p podcast-name
 
+Sometimes you may want to save data about a podcast in the store, but not continue refreshing the podcast from the RSS feed:
+
+    pod set-inactive podcast-name
+
+Using `pod refresh` and specifying the podcast by title will force an RSS feed refresh:
+
+    pod refresh -p inactive-podcast-name
+
+To reactivate a podcast and resume updating it from RSS feed data regularly:
+
+    pod set-active podcast-name
+
 Download all new episodes, or new episodes for just a specific podcast:
 
     pod download

--- a/conftest.py
+++ b/conftest.py
@@ -181,7 +181,7 @@ def store_data(now, yesterday, podcast_episode_data, other_podcast_episode_data)
         "other": {
             "title": "other",
             "feed": "http://other.thing/rss",
-            "tags": [],
+            "tags": ["inactive"],
             "episode_data": {},
             "created_at": yesterday.isoformat(),
             "updated_at": now.isoformat(),

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -562,6 +562,27 @@ def rm(ctx: click.Context, title: str):
 @cli.command()
 @click.pass_context
 @click.argument("podcast")
+@catch_pod_store_errors
+@require_store
+@git_add_and_commit(
+    secure_git_mode_message="Tagged items.",
+    commit_message_builder=tagger_commit_message_builder,
+)
+@save_store_changes
+def set_inactive(ctx: click.Context, podcast: str):
+    """Set a podcast to `inactive`. The RSS feed data will no longer be refreshed.
+
+    PODCAST: title of podcast to set as 'inactive'
+    """
+    store = ctx.obj
+
+    podcast = store.podcasts.get(podcast)
+    podcast.tag("inactive")
+
+
+@cli.command()
+@click.pass_context
+@click.argument("podcast")
 @click.option("--tag", "-t", multiple=True, required=True, help="Tags to apply.")
 @click.option(
     "-e",

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -535,7 +535,7 @@ def refresh(
 
 @cli.command()
 @click.pass_context
-@click.argument("title")
+@click.argument("podcast")
 @click.option(
     "-f",
     "--force",
@@ -547,16 +547,16 @@ def refresh(
 )
 @catch_pod_store_errors
 @require_store
-@git_add_and_commit(message="Removed podcast: {title!r}.", params=["title"])
+@git_add_and_commit(message="Removed podcast: {podcast!r}.", params=["podcast"])
 @save_store_changes
-def rm(ctx: click.Context, title: str):
+def rm(ctx: click.Context, podcast: str):
     """Remove a podcast from the store. This command will NOT delete the podcast
     episodes that have been downloaded.
 
-    TITLE: title of podcast to remove
+    PODCAST: title of podcast to remove
     """
     store = ctx.obj
-    store.podcasts.delete(title)
+    store.podcasts.delete(podcast)
 
 
 @cli.command()

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -569,6 +569,29 @@ def rm(ctx: click.Context, title: str):
     commit_message_builder=tagger_commit_message_builder,
 )
 @save_store_changes
+def set_active(ctx: click.Context, podcast: str):
+    """Set a podcast to `active`. The RSS feed data be refreshed.
+
+    Reverses the `set-inactive` command.
+
+    PODCAST: title of podcast to set as 'active'
+    """
+    store = ctx.obj
+
+    podcast = store.podcasts.get(podcast)
+    podcast.untag("inactive")
+
+
+@cli.command()
+@click.pass_context
+@click.argument("podcast")
+@catch_pod_store_errors
+@require_store
+@git_add_and_commit(
+    secure_git_mode_message="Tagged items.",
+    commit_message_builder=tagger_commit_message_builder,
+)
+@save_store_changes
 def set_inactive(ctx: click.Context, podcast: str):
     """Set a podcast to `inactive`. The RSS feed data will no longer be refreshed.
 

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -167,8 +167,8 @@ def download(
 ):
     """Download podcast episodes."""
     store = ctx.obj
-    tagged = tagged or []
-    untagged = untagged or []
+    tagged = list(tagged or [])
+    untagged = list(untagged or [])
 
     filter = get_filter_from_command_arguments(
         store=store,
@@ -340,8 +340,8 @@ def ls(
     the provided flags and command options.
     """
     store = ctx.obj
-    tagged = tagged or []
-    untagged = untagged or []
+    tagged = list(tagged or [])
+    untagged = list(untagged or [])
 
     lister = get_lister_from_command_arguments(
         store=store,
@@ -512,8 +512,11 @@ def refresh(
 ):
     """Refresh podcast episode data from the RSS feed."""
     store = ctx.obj
-    tagged = tagged or []
-    untagged = untagged or []
+    tagged = list(tagged or [])
+    untagged = list(untagged or [])
+
+    if not podcast:
+        untagged.append("inactive")
 
     filter = get_filter_from_command_arguments(
         store=store,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,6 +289,11 @@ def test_rm_aborts_if_not_confirmed(runner):
     assert result.exit_code == 1
 
 
+def test_set_active(runner):
+    result = runner.invoke(cli, ["set-active", "other"])
+    assert result.exit_code == 0
+
+
 def test_set_inactive(runner):
     result = runner.invoke(cli, ["set-inactive", "greetings"])
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,18 +249,16 @@ def test_mv(runner):
     assert result.exit_code == 0
 
 
-def test_refresh_all_podcasts(runner):
+def test_refresh_all_podcasts_ignores_inactive_podcasts(runner):
     result = runner.invoke(cli, ["refresh"])
     assert result.exit_code == 0
-    assert (
-        result.output == "Refreshing farewell\nRefreshing other\nRefreshing greetings\n"
-    )
+    assert result.output == "Refreshing farewell\nRefreshing greetings\n"
 
 
-def test_refresh_single_podcast(runner):
-    result = runner.invoke(cli, ["refresh", "-p", "greetings"])
+def test_refresh_single_podcast_will_force_refresh_of_inactive_podcast(runner):
+    result = runner.invoke(cli, ["refresh", "-p", "other"])
     assert result.exit_code == 0
-    assert result.output == "Refreshing greetings\n"
+    assert result.output == "Refreshing other\n"
 
 
 def test_refresh_podcasts_with_tag(runner):
@@ -272,7 +270,7 @@ def test_refresh_podcasts_with_tag(runner):
 def test_refresh_podcasts_without_tag(runner):
     result = runner.invoke(cli, ["refresh", "-u", "hello"])
     assert result.exit_code == 0
-    assert result.output == "Refreshing farewell\nRefreshing other\n"
+    assert result.output == "Refreshing farewell\n"
 
 
 def test_refresh_podcast_times_out(timed_out_request, runner):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,6 +289,11 @@ def test_rm_aborts_if_not_confirmed(runner):
     assert result.exit_code == 1
 
 
+def test_set_inactive(runner):
+    result = runner.invoke(cli, ["set-inactive", "greetings"])
+    assert result.exit_code == 0
+
+
 def test_tag_a_podcast(runner):
     result = runner.invoke(cli, ["tag", "greetings", "-t", "foobar"])
     assert result.exit_code == 0

--- a/tests/test_command_listing.py
+++ b/tests/test_command_listing.py
@@ -107,7 +107,7 @@ def test_episode_lister_list_raises_exception_when_no_episodes_found(store):
 def test_podcast_lister_list(podcast_lister):
     assert list(podcast_lister.list()) == [
         "farewell [1]",
-        "other",
+        "other -> inactive",
         "greetings [1] -> hello",
     ]
 
@@ -124,6 +124,7 @@ updated at: {now_formatted}""",
         "",
         f"""other
 0 new episodes
+tags: inactive
 feed: http://other.thing/rss
 created at: {yesterday_formatted}
 updated at: {now_formatted}""",


### PR DESCRIPTION
Allows a user to set a podcast to `inactive`. A podcast in this state will retain its data in the store, but will not be updated from RSS feed data when the `refresh` command is run.

The implementation sets/looks for an `inactive` tag when running the refresh command.

Closes #90 