### PR TITLE
[105] More flexible `tag` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,21 +91,16 @@ Download all new episodes, or new episodes for just a specific podcast:
 
 By default podcast episodes will be downloaded to e.g. `/home/<username>/Podcasts/<podcast-name>/<001-episode-title>.mp3`. See the configuration section for how to adjust the download path.
 
-Sometimes you may want to mark an episode as being not-new without actually downloading it. Do that using the `mark` command. By default you will interactively choose which episodes to mark, or you can bulk-mark all episodes. Either of these strategies can be applied to _all_ new episodes, or just the episodes of a specific podcast:
+Sometimes you may want to mark an episode as being not-new without actually downloading it. Do that using the `mark-as-old` command. By default you will interactively choose which episodes to mark, or you can bulk-mark all episodes. Either of these strategies can be applied to _all_ new episodes, or just the episodes of a specific podcast:
 
     pod mark-as-old
     pod mark-as-old --bulk
 
     pod mark-as-old -p podcast-name
-    pod mark-as-old --bulk -p podcast-name
 
-The reverse can be accomplished as well, if you want to download episodes that have been previously marked as "old":
+The reverse can be accomplished as well, if you want to download episodes that have been previously marked as "old". All the same command options apply:
 
     pod mark-as-new
-    pod mark-as-new --bulk
-
-    pod mark-as-new -p podcast-name
-    pod mark-as-new --bulk -p podcast-name
 
 Rename a podcast in the store:
 
@@ -129,35 +124,31 @@ Unencrypt a store that is set up as encrypted:
 
     pod unencrypt-store
 
-Podcasts and episodes can be marked with tags:
+Podcasts and episodes can be marked with tags. The `tag` command allows tagging a single podcast or episode:
 
-    pod tag podcast-name tag-name
-    pod tag podcast-name tag-name --episode episode-id
+    pod tag -p podcast-name -t tag-name
+    pod tag -p podcast-name -e episode-id -t tag-name
 
-Note that to reference an episode to tag you will need the episode ID. You can get that using the `ls --verbose --episodes` command.
+You can also tag groups of podcasts, or episodes, or episodes for a particular podcast:
 
-Podcasts and episodes can be untagged with a similar command:
+    pod tag --podcasts -t tag-name
+    pod tag --episodes -t tag-name
+    pod tag -p podcast-name --episodes -t tag-name
 
-    pod untag podcast-name tag-name
-    pod untag podcast-name tag-name --episode episode-id
+By default, the `tag` command works on groups of items. By default, it tags episodes.
 
-Episodes can be tagged in groups:
+When tagging groups of items, you can interactively select which items to tag or apply the tag to the whole group by using the `interactive` and `bulk` mode options:
 
-    pod tag-episodes tag-name
+    pod tag --podcasts --interactive -t tag-name
+    pod tag --episodes --bulk -t tag-name
 
-By default you will be prompted to select which episodes to apply the tag too, but you can bulk aply the tag to every episode in the group without being prompted:
+By default, group tagging operations are run in interactive mode. Bulk mode tagging operations will prompt the user for a single confirmation, unless you pass in the `force` flag:
 
-    pod tag-episodes tag-name --bulk
+    pod tag --episodes --bulk --force -t tag-name
 
-Either mode can be restricted to episodes for a single podcast:
+Any of the tagging commands can be used to remove tags (rather than apply them) using the `untag` option:
 
-    pod tag-episodes -p podcast-name tag-name
-
-A similar command allows untagging episodes in groups:
-
-    pod untag-episodes tag-name
-    pod untag-episodes tag-name --bulk
-    pod untag-episodes -p podcast-name tag-name
+    pod tag --untag --episodes -t tag-name
 
 ## Configuration
 
@@ -190,12 +181,13 @@ Write tests for your changes!
 
 The CLI is built using the [Click](https://click.palletsprojects.com/) library, so some familiarity with that library will help in understanding/contributing to the code.
 
-This project uses [black](https://github.com/psf/black) for code formatting/linting, and [https://pycqa.github.io/isort/](isort) for import linting. [PEP-8](https://www.python.org/dev/peps/pep-0008/) is generally followed, with the exception of an 88 character line limit rather than 79 characters (which is in line with the default behavior for `black`).
+This project uses [flake8](https://flake8.pycqa.org/en/latest/) for linting, [black](https://github.com/psf/black) for code formatting, and [https://pycqa.github.io/isort/](isort) for import standards. [PEP-8](https://www.python.org/dev/peps/pep-0008/) is generally followed, with the exception of an 88 character line limit rather than 79 characters (which is in line with the default behavior for `black`).
 
 Tests are run using [pytest](https://docs.pytest.org/) and run against multiple Python versions using [tox](https://tox.wiki/en/latest/).
 
 Code will not be accepted that doesn't pass the test suite or the code style checks. You can run the linters and tests yourself locally before opening the PR. These commands should do it (run from the root directory of the git repo):
 
+    flake8 .
     black .
     isort .
     pytest

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -606,18 +606,31 @@ def set_inactive(ctx: click.Context, podcast: str):
 @cli.command()
 @click.pass_context
 @click.option("--tag", "-t", multiple=True, required=True, help="Tags to apply.")
-@click.option("--untag", "-u", is_flag=True)
-@click.option("--podcast", "-p", default=None)
+@click.option(
+    "--untag",
+    "-u",
+    is_flag=True,
+    help="Remove the specified tags (rather than apply them).",
+)
+@click.option(
+    "--podcast", "-p", default=None, help="(podcast title): Tag a single podcast."
+)
 @click.option(
     "-e",
     "--episode",
     default=None,
-    help="(episode ID): Episode to tag. "
+    help="(episode ID): Tag a single episode. "
     "Note that this is the ID from the `ls --episodes --verbose` listing, not the "
     "episode number.",
 )
-@click.option("--episodes/--podcasts", default=True)
-@click.option("--interactive/--bulk", default=True)
+@click.option(
+    "--episodes/--podcasts", default=True, help="Tag episodes or podcasts in groups."
+)
+@click.option(
+    "--interactive/--bulk",
+    default=True,
+    help="Interactively determine which items to tag, or apply the tag to all items.",
+)
 @click.option(
     "-f",
     "--force",
@@ -644,13 +657,22 @@ def tag(
     interactive: bool,
     force: bool,
 ):
-    """Tag a single podcast or episode with an arbitrary text tag. If the optional
-    episode ID is provided, it will be tagged. Otherwise, the podcast itself will
-    be tagged.
+    """Tag (or untag) podcasts or episodes with arbitrary tags.
 
-    Note that tagging an episode requires the user to provide the podcast AND episode.
+    By default, this command works on groups (rather than individual items). Determine
+    which type of item to tag using the `--episodes` or `--podcasts` option.
+    (Defaults to episodes.)
 
-    PODCAST: title of podcast
+    When working in group mode, you can interactively determine which items to tag
+    using the `--interactive` option, or apply the tag to all items in the group using
+    the `--bulk` tag. (Defaults to interactive mode.)
+
+    In bulk mode, a single confirmation prompt will be shown unless the user passes in
+    the `--force` flag.
+
+    It is possible to tag individual items instead using the `--podcast` and `--episode`
+    options. Specify a podcast by title to tag the podcast. To tag an episode, specify
+    the podcast by title and then specify the episode by ID.
     """
     tag_episodes = bool(not podcast or episode) and bool(episodes or episode)
     store = ctx.obj

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -336,6 +336,14 @@ def test_tag_episodes_interactive_mode(runner):
     assert "Tagged as foo: greetings" in result.output
 
 
+def test_tag_with_untag_flag(runner):
+    result = runner.invoke(
+        cli, ["tag", "-t", "foo", "--untag", "--episodes", "--bulk", "--force"]
+    )
+    assert result.exit_code == 0
+    assert "Untagged as foo: greetings" in result.output
+
+
 def test_unencrypt_store(runner):
     with open(TEST_GPG_ID_FILE_PATH, "w") as f:
         f.write("abc@xyz.com")
@@ -347,40 +355,3 @@ def test_unencrypt_store(runner):
 def test_unencrypt_aborts_if_not_confirmed(runner):
     result = runner.invoke(cli, ["unencrypt-store"], input="\n")
     assert result.exit_code == 1
-
-
-def test_untag_a_podcast(runner):
-    result = runner.invoke(cli, ["untag", "greetings", "-t", "hello"])
-    assert result.exit_code == 0
-    assert result.output == "Untagged as hello: greetings.\n"
-
-
-def test_untag_single_pocast_episode(runner):
-    result = runner.invoke(cli, ["untag", "greetings", "--episode", "aaa", "-t", "new"])
-    assert result.exit_code == 0
-    assert result.output == "Untagged as new: greetings -> [0023] hello.\n"
-
-
-def test_untag_episodes_all_episodes_bulk_mode(runner):
-    result = runner.invoke(cli, ["untag-episodes", "-t", "foo", "--force", "--bulk"])
-    assert result.exit_code == 0
-    assert "Untagged as foo: farewell" in result.output
-    assert "Untagged as foo: greetings" in result.output
-
-
-def test_untag_episodes_for_single_podcast(runner):
-    result = runner.invoke(
-        cli, ["untag-episodes", "-t", "foo", "--force", "--bulk", "-p", "greetings"]
-    )
-    assert result.exit_code == 0
-    assert "Untagged as foo: farewell" not in result.output
-    assert "Untagged as foo: greetings" in result.output
-
-
-def test_untag_episodes_interactive_mode(runner):
-    result = runner.invoke(
-        cli, ["untag-episodes", "-t", "foo", "--interactive"], input="n\ny\nn\n"
-    )
-    assert result.exit_code == 0
-    assert "Untagged as foo: farewell" not in result.output
-    assert "Untagged as foo: greetings" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -299,22 +299,22 @@ def test_set_inactive(runner):
     assert result.exit_code == 0
 
 
-def test_tag_a_podcast(runner):
-    result = runner.invoke(cli, ["tag", "greetings", "-t", "foobar"])
+def test_tag_single_podcast(runner):
+    result = runner.invoke(cli, ["tag", "--bulk", "-p", "greetings", "-t", "foobar"])
     assert result.exit_code == 0
     assert result.output == "Tagged as foobar: greetings.\n"
 
 
-def test_tag_a_pocast_episode(runner):
+def test_tag_single_episode(runner):
     result = runner.invoke(
-        cli, ["tag", "greetings", "--episode", "aaa", "-t", "foobar"]
+        cli, ["tag", "--bulk", "-p", "greetings", "-e", "aaa", "-t", "foobar"]
     )
     assert result.exit_code == 0
     assert result.output == "Tagged as foobar: greetings -> [0023] hello.\n"
 
 
-def test_tag_episodes_all_episodes_bulk_mode(runner):
-    result = runner.invoke(cli, ["tag-episodes", "-t", "foo", "--force", "--bulk"])
+def test_tag_all_episodes_bulk_mode(runner):
+    result = runner.invoke(cli, ["tag", "-t", "foo", "--force", "--bulk"])
     assert result.exit_code == 0
     assert "Tagged as foo: farewell" in result.output
     assert "Tagged as foo: greetings" in result.output
@@ -322,7 +322,7 @@ def test_tag_episodes_all_episodes_bulk_mode(runner):
 
 def test_tag_episodes_for_single_podcast(runner):
     result = runner.invoke(
-        cli, ["tag-episodes", "-t", "zozo", "--force", "--bulk", "-p", "greetings"]
+        cli, ["tag", "-t", "zozo", "--force", "--bulk", "-p", "greetings"]
     )
     assert result.exit_code == 0
     assert "Tagged as zozo: farewell" not in result.output
@@ -330,9 +330,7 @@ def test_tag_episodes_for_single_podcast(runner):
 
 
 def test_tag_episodes_interactive_mode(runner):
-    result = runner.invoke(
-        cli, ["tag-episodes", "-t", "foo", "--interactive"], input="n\ny\n"
-    )
+    result = runner.invoke(cli, ["tag", "-t", "foo", "--interactive"], input="n\ny\n")
     assert result.exit_code == 0
     assert "Tagged as foo: farewell" not in result.output
     assert "Tagged as foo: greetings" in result.output

--- a/tests/test_command_decorators.py
+++ b/tests/test_command_decorators.py
@@ -33,8 +33,8 @@ def test_catch_pod_store_errors_decorator_aborts_command_and_displays_error_mess
     )
 
 
-def test_conditional_confirmation_prompt_param_does_not_match_value():
-    @decorators.conditional_confirmation_prompt(param="hello", value=False)
+def test_conditional_confirmation_prompt_params_do_not_match_all_conditions():
+    @decorators.conditional_confirmation_prompt(hello=True, foo="bar")
     def no_match(ctx):
         return True
 
@@ -42,10 +42,8 @@ def test_conditional_confirmation_prompt_param_does_not_match_value():
     assert no_match(ctx) is True
 
 
-def test_conditional_confirmation_prompt_param_matches_value_but_override_flag_is_set():
-    @decorators.conditional_confirmation_prompt(
-        param="hello", value=True, override="flagged"
-    )
+def test_conditional_confirmation_prompt_params_match_conditions_but_override_is_set():
+    @decorators.conditional_confirmation_prompt(hello=True, override="flagged")
     def flagged(ctx):
         return True
 
@@ -53,12 +51,12 @@ def test_conditional_confirmation_prompt_param_matches_value_but_override_flag_i
     assert flagged(ctx) is True
 
 
-def test_conditional_confirmation_prompt_param_matches_no_override_prompt_confirmed(
+def test_conditional_confirmation_prompt_user_confirms_choice(
     mocker,
 ):
     mocker.patch("click.prompt", return_value="y")
 
-    @decorators.conditional_confirmation_prompt(param="hello", value=True)
+    @decorators.conditional_confirmation_prompt(hello=True)
     def prompt_passed(ctx):
         return True
 
@@ -66,12 +64,12 @@ def test_conditional_confirmation_prompt_param_matches_no_override_prompt_confir
     assert prompt_passed(ctx) is True
 
 
-def test_conditional_confirmation_prompt_param_no_override_prompt_not_confirmed(
+def test_conditional_confirmation_prompt_user_does_not_confirm_choice(
     mocker,
 ):
     mocker.patch("click.prompt", return_value="n")
 
-    @decorators.conditional_confirmation_prompt(param="hello", value=True)
+    @decorators.conditional_confirmation_prompt(hello=True)
     def prompt_failed(ctx):
         return True
 


### PR DESCRIPTION
Expands the `tag` command to encompass tagging groups of podcasts and episodes, and to perform untagging options by specifying a flag.

Replaces the previous `tag-episodes`, `untag`, and `untag-episodes` commands.

Closes #105 
Closes #83 