### PR TITLE
[086] Use episode number instead of episode ID for look up in CLI

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -104,7 +104,7 @@ def podcast_episode_data(now, yesterday):
     return {
         "aaa": {
             "id": "aaa",
-            "episode_number": "0023",
+            "episode_number": 23,
             "title": "hello",
             "short_description": "hello world",
             "long_description": "hello world (longer description)",
@@ -116,7 +116,7 @@ def podcast_episode_data(now, yesterday):
         },
         "zzz": {
             "id": "zzz",
-            "episode_number": "0011",
+            "episode_number": 11,
             "title": "goodbye",
             "short_description": "goodbye world",
             "long_description": "goodbye world (longer description)",
@@ -134,7 +134,7 @@ def other_podcast_episode_data(now):
     return {
         "111": {
             "id": "111",
-            "episode_number": "0001",
+            "episode_number": 1,
             "title": "gone",
             "short_description": "all gone",
             "long_description": "all gone (longer description)",
@@ -146,7 +146,7 @@ def other_podcast_episode_data(now):
         },
         "222": {
             "id": "222",
-            "episode_number": "0002",
+            "episode_number": 2,
             "title": "not forgotten",
             "short_description": "never forgotten",
             "long_description": "never forgotten (longer description)",
@@ -219,7 +219,7 @@ def episode(now, podcast):
     return Episode(
         podcast=podcast,
         id="aaa",
-        episode_number="0023",
+        episode_number=23,
         title="hello",
         short_description="hello world",
         long_description="hello world (longer description)",

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -619,9 +619,9 @@ def set_inactive(ctx: click.Context, podcast: str):
     "-e",
     "--episode",
     default=None,
-    help="(episode ID): Tag a single episode. "
-    "Note that this is the ID from the `ls --episodes --verbose` listing, not the "
-    "episode number.",
+    help="(episode number): Tag a single podcast episode. "
+    "Note that you must specify a podcast this episode belongs to using the "
+    "`--podcast` option.",
 )
 @click.option(
     "--episodes/--podcasts", default=True, help="Tag episodes or podcasts in groups."
@@ -672,12 +672,12 @@ def tag(
 
     It is possible to tag individual items instead using the `--podcast` and `--episode`
     options. Specify a podcast by title to tag the podcast. To tag an episode, specify
-    the podcast by title and then specify the episode by ID.
+    the podcast by title and then specify the episode by episode number.
     """
     tag_episodes = bool(not podcast or episode) and bool(episodes or episode)
     store = ctx.obj
     if episode:
-        filters = {"id": episode}
+        filters = {"episode_number": episode.rjust(4, "0")}
     else:
         filters = {}
 

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -618,6 +618,7 @@ def set_inactive(ctx: click.Context, podcast: str):
 @click.option(
     "-e",
     "--episode",
+    type=int,
     default=None,
     help="(episode number): Tag a single podcast episode. "
     "Note that you must specify a podcast this episode belongs to using the "
@@ -676,8 +677,8 @@ def tag(
     """
     tag_episodes = bool(not podcast or episode) and bool(episodes or episode)
     store = ctx.obj
-    if episode:
-        filters = {"episode_number": episode.rjust(4, "0")}
+    if episode is not None:
+        filters = {"episode_number": int(episode)}
     else:
         filters = {}
 

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -678,7 +678,7 @@ def tag(
     tag_episodes = bool(not podcast or episode) and bool(episodes or episode)
     store = ctx.obj
     if episode is not None:
-        filters = {"episode_number": int(episode)}
+        filters = {"episode_number": episode}
     else:
         filters = {}
 

--- a/pod_store/commands/listing.py
+++ b/pod_store/commands/listing.py
@@ -104,7 +104,7 @@ class EpisodeLister(Lister):
             downloaded_at_msg = ""
 
         return VERBOSE_EPISODE_LISTING_TEMPLATE.format(
-            episode_number=e.episode_number,
+            episode_number=e.padded_episode_number,
             title=e.title,
             id=e.id,
             tags_msg=tags_msg,
@@ -128,7 +128,7 @@ class EpisodeLister(Lister):
         # The template kwargs have to be gathered for use in the description message
         # helper anyway. To avoid doing so twice I build a dict for them here.
         template_kwargs = {
-            "episode_number": episode.episode_number,
+            "episode_number": episode.padded_episode_number,
             "title": episode.title,
             "downloaded_msg": downloaded_msg,
             "tags_msg": tags_msg,

--- a/pod_store/commands/tagging.py
+++ b/pod_store/commands/tagging.py
@@ -40,7 +40,7 @@ TAG_PODCASTS_INTERACTIVE_MODE_PROMPT_MESSAGE_TEMPLATE = (
 
 TAGGED_EPISODE_MESSAGE_TEMPLATE = (
     "{tagger.capitalized_performed_action} as {tagger.tag_listing}: "
-    "{item.podcast.title} -> [{item.episode_number}] {item.title}."
+    "{item.podcast.title} -> [{item.padded_episode_number}] {item.title}."
 )
 
 TAGGED_PODCAST_MESSAGE_TEMPLATE = (

--- a/pod_store/episodes.py
+++ b/pod_store/episodes.py
@@ -186,7 +186,7 @@ class Episode:
         file_type = os.path.splitext(self.url)[1][:4]
         return os.path.join(
             self.podcast.episode_downloads_path,
-            f"{self.episode_number}-{cleaned_title}{file_type}",
+            f"{self.padded_episode_number}-{cleaned_title}{file_type}",
         )
 
     @property
@@ -196,6 +196,14 @@ class Episode:
         Looks for the presence of a 'new' tag assigned to the episode.
         """
         return "new" in self.tags
+
+    @property
+    def padded_episode_number(self) -> str:
+        """Zero-padded episode number.
+
+        Provided for consistency in filenames and listing output.
+        """
+        return str(self.episode_number).rjust(4, "0")
 
     def download(self) -> None:
         """Download the audio file of the episode to the file system."""

--- a/pod_store/podcasts.py
+++ b/pod_store/podcasts.py
@@ -195,10 +195,9 @@ class Podcast:
 
             # If no episode number can be parsed from the RSS feed data, guess based
             # on position in the loop.
-            episode_number = episode_data.get("episode_number") or (
-                str(number_of_entries - entry_number)
+            episode_data["episode_number"] = episode_data.get("episode_number") or (
+                number_of_entries - entry_number
             )
-            episode_data["episode_number"] = self._pad_episode_number(episode_number)
 
             episode = self.episodes.get(episode_data["id"], allow_empty=True)
             if episode:
@@ -268,12 +267,15 @@ class Podcast:
         url = self._get_download_url(links)
         published_parsed = datetime(*published_parsed[:6])
 
+        if itunes_episode:
+            episode_number = int(itunes_episode)
+        else:
+            episode_number = None
+
         if subtitle:
             short_description = self._strip_html_and_non_ascii_characters(subtitle)
         else:
             short_description = long_description
-
-        episode_number = itunes_episode
 
         if updated_parsed:
             updated_parsed = datetime(*updated_parsed[:6])
@@ -286,8 +288,8 @@ class Podcast:
             "long_description": long_description,
             "url": url,
             "created_at": published_parsed,
-            "short_description": short_description,
             "episode_number": episode_number,
+            "short_description": short_description,
             "updated_at": updated_parsed,
         }
 
@@ -317,8 +319,3 @@ class Podcast:
                 return audio_link["href"]
             download_urls.append(audio_link["href"])
         return download_urls[0]
-
-    @staticmethod
-    def _pad_episode_number(episode_number: str) -> str:
-        """Create an episode number padded with up to 3 zeros."""
-        return episode_number.rjust(4, "0")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -348,7 +348,7 @@ def test_tag_single_podcast(runner):
 
 def test_tag_single_episode(runner):
     result = runner.invoke(
-        cli, ["tag", "--bulk", "-p", "greetings", "-e", "aaa", "-t", "foobar"]
+        cli, ["tag", "--bulk", "-p", "greetings", "-e", "023", "-t", "foobar"]
     )
     assert result.exit_code == 0
     assert result.output == "Tagged as foobar: greetings -> [0023] hello.\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -352,7 +352,6 @@ def test_tag_single_episode(runner):
     )
     assert result.exit_code == 0
     assert result.output == "Tagged as foobar: greetings -> [0023] hello.\n"
-    assert False  # replace duplicate rjust logic for padding episode number
 
 
 def test_tag_with_untag_flag(runner):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -352,6 +352,7 @@ def test_tag_single_episode(runner):
     )
     assert result.exit_code == 0
     assert result.output == "Tagged as foobar: greetings -> [0023] hello.\n"
+    assert False  # replace duplicate rjust logic for padding episode number
 
 
 def test_tag_with_untag_flag(runner):

--- a/tests/test_episodes.py
+++ b/tests/test_episodes.py
@@ -38,7 +38,7 @@ def test_episode_download_path_is_correct_path_for_filetype_without_invalid_char
     episode = Episode(
         podcast=podcast,
         id="bbb",
-        episode_number="0981",
+        episode_number=981,
         title="foo/bar: the fin?al[ RE:^ckONing",
         short_description="foo",
         long_description="foo (longer description)",
@@ -114,7 +114,7 @@ def test_episode_untag(episode):
 def test_episode_to_json(now, episode):
     assert episode.to_json() == {
         "id": "aaa",
-        "episode_number": "0023",
+        "episode_number": 23,
         "title": "hello",
         "short_description": "hello world",
         "long_description": "hello world (longer description)",

--- a/tests/test_podcasts.py
+++ b/tests/test_podcasts.py
@@ -61,7 +61,7 @@ def test_podcast_refresh(mocked_feedparser_parse, now, podcast):
                     },
                     {
                         "id": "https://www.foo.bar/aaa",
-                        "itunes_episode": "0023",
+                        "itunes_episode": "23",
                         "title": "hello-updated",
                         "summary": "hello world",
                         "links": [
@@ -83,13 +83,15 @@ def test_podcast_refresh(mocked_feedparser_parse, now, podcast):
     assert podcast.updated_at == now
     assert podcast.episodes.ids == ["aaa", "ccc"]
 
-    assert podcast.episodes.get("aaa").title == "hello-updated"
+    old_episode = podcast.episodes.get("aaa")
+    assert old_episode.title == "hello-updated"
+    assert old_episode.episode_number == 23
 
     new_episode = podcast.episodes.get("ccc")
     assert new_episode.download_path == os.path.join(
         TEST_PODCAST_EPISODE_DOWNLOADS_PATH, "0002-no-number-provided.ogg"
     )
-    assert new_episode.episode_number == "0002"
+    assert new_episode.episode_number == 2
     assert new_episode.short_description == "this is a short description"
     assert new_episode.long_description == "this is a long description"
 


### PR DESCRIPTION
RSS feed derived episode IDs are often lengthy and unwieldy. Rather than force the user to use them to reference an individual podcast episode, use the episode number instead.

Involves changing the way episode numbers are saved in store data. Since previously they were only used for presentation in their zero-padded form, they had been stored that way. But it is more straightforward to store them as integers, now that they can be used as a lookup reference.

Closes #86 