### PR TITLE
[113] Download single podcast episodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,12 @@ To reactivate a podcast and resume updating it from RSS feed data regularly:
 
     pod set-active podcast-name
 
-Download all new episodes, or new episodes for just a specific podcast:
+Download all new episodes, or new episodes for just a specific podcast, or episodes with certain tags, or just a single episode:
 
     pod download
     pod download -p podcast-name
+    pod download -t tag-name
+    pod download -p podcast-name -e episode-number
 
 By default podcast episodes will be downloaded to e.g. `/home/<username>/Podcasts/<podcast-name>/<001-episode-title>.mp3`. See the configuration section for how to adjust the download path.
 
@@ -127,7 +129,7 @@ Unencrypt a store that is set up as encrypted:
 Podcasts and episodes can be marked with tags. The `tag` command allows tagging a single podcast or episode:
 
     pod tag -p podcast-name -t tag-name
-    pod tag -p podcast-name -e episode-id -t tag-name
+    pod tag -p podcast-name -e episode-number -t tag-name
 
 You can also tag groups of podcasts, or episodes, or episodes for a particular podcast:
 

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -141,6 +141,15 @@ def add(ctx: click.Context, title: str, feed: str):
     help="(podcast title): Download only episodes for the specified podcast.",
 )
 @click.option(
+    "-e",
+    "--episode",
+    type=int,
+    default=None,
+    help="(episode number): Download a single episode. "
+    "Note that you must specify the podcast this episode belongs to using the "
+    "`--podcast` option.",
+)
+@click.option(
     "--tagged",
     "-t",
     multiple=True,
@@ -162,6 +171,7 @@ def add(ctx: click.Context, title: str, feed: str):
 def download(
     ctx: click.Context,
     podcast: Optional[str],
+    episode: Optional[int],
     tagged: Optional[List[str]],
     untagged: Optional[List[str]],
 ):
@@ -170,13 +180,21 @@ def download(
     tagged = list(tagged or [])
     untagged = list(untagged or [])
 
+    if episode is not None:
+        new_episodes = False
+        filters = {"episode_number": episode}
+    else:
+        new_episodes = True
+        filters = {}
+
     filter = get_filter_from_command_arguments(
         store=store,
-        new_episodes=True,
+        new_episodes=new_episodes,
         filter_for_episodes=True,
         podcast_title=podcast,
         tagged=tagged,
         untagged=untagged,
+        **filters,
     )
 
     for ep in filter.items:

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -653,7 +653,7 @@ def tag(
     tag: List[str],
     untag: bool,
     podcast: Optional[str],
-    episode: Optional[str],
+    episode: Optional[int],
     episodes: bool,
     interactive: bool,
     force: bool,

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -175,7 +175,13 @@ def download(
     tagged: Optional[List[str]],
     untagged: Optional[List[str]],
 ):
-    """Download podcast episodes."""
+    """Download podcast episodes. Use the command options to download all new episodes,
+    only new episodes for a specific podcast, only episodes with specific tags, or only
+    a single episode.
+
+    By default, only new episodes will be downloaded, but when specifying a single
+    episode it will be downloaded whether or not it is marked as 'new'.
+    """
     store = ctx.obj
     tagged = list(tagged or [])
     untagged = list(untagged or [])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,6 +52,17 @@ def test_download_single_podcast_new_episodes(runner):
     assert result.output == f"Downloading: {TEST_EPISODE_DOWNLOAD_PATH}.\n\n"
 
 
+def test_download_single_episode(runner):
+    download_path = os.path.join(
+        TEST_PODCAST_EPISODE_DOWNLOADS_PATH, "0011-goodbye.mp3"
+    )
+    # Tests against an episode that is not tagged as 'new', to verify that it will
+    # still be downloaded if it is specifically chosen by the user.
+    result = runner.invoke(cli, ["download", "-p", "greetings", "-e", "11"])
+    assert result.exit_code == 0
+    assert result.output == f"Downloading: {download_path}.\n\n"
+
+
 def test_download_new_episodes_with_tag(runner):
     result = runner.invoke(cli, ["download", "-t", "bar"])
     assert result.exit_code == 0


### PR DESCRIPTION
Extends the `download` command to allow the user to download a single podcast episode.

Closes #113 