### PR TITLE
[114] `ls` single episode data

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,12 @@ Get more detail with any `ls` command by adding the `--verbose` flag:
 
     pod ls --verbose --all
 
-List new episodes, list all episodes, list new episodes for a specific podcast:
+List new episodes, list all episodes, list new episodes for a specific podcast, list data for only a single podcast episode:
 
     pod ls --episodes
     pod ls --all --episodes
     pod ls -p podcast-name
+    pod ls -p podcast-name -e episode-number
 
 Refresh episode data for all podcasts from their RSS feeds, or just a specific podcast:
 

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -330,6 +330,15 @@ def init(git: bool, git_url: Optional[str], gpg_id: Optional[str]):
     help="(podcast title): List only episodes for the specified podcast.",
 )
 @click.option(
+    "-e",
+    "--episode",
+    type=int,
+    default=None,
+    help="(episode number): List a single podcast episode. "
+    "Note that you must specify a podcast this episode belongs to using the "
+    "`--podcast` option.",
+)
+@click.option(
     "--tagged",
     "-t",
     multiple=True,
@@ -354,6 +363,7 @@ def ls(
     new: bool,
     episodes: bool,
     podcast: Optional[str],
+    episode: Optional[int],
     tagged: Optional[List[str]],
     untagged: Optional[List[str]],
     verbose: bool,
@@ -367,13 +377,23 @@ def ls(
     tagged = list(tagged or [])
     untagged = list(untagged or [])
 
+    if episode is not None:
+        list_episodes = True
+        new_episodes = False
+        filters = {"episode_number": episode}
+    else:
+        list_episodes = episodes
+        new_episodes = new
+        filters = {}
+
     lister = get_lister_from_command_arguments(
         store=store,
-        new_episodes=new,
-        list_episodes=episodes,
+        new_episodes=new_episodes,
+        list_episodes=list_episodes,
         podcast_title=podcast,
         tagged=tagged,
         untagged=untagged,
+        **filters,
     )
     for msg in lister.list(verbose=verbose):
         click.echo(msg)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -212,10 +212,12 @@ def test_ls_podcast_episodes(runner):
 
 
 def test_ls_single_podcast_episode(runner):
-    result = runner.invoke(cli, ["ls", "-p", "greetings", "-e", "23"])
+    # Test against an episode not marked as 'new' to verify that the new/not-new flag
+    # is ignored in cases where the user is specifying a single episode.
+    result = runner.invoke(cli, ["ls", "-p", "greetings", "-e", "11"])
     assert result.exit_code == 0
-    assert "0023" in result.output
-    assert "0011" not in result.output  # does not show other podcast episode data
+    assert "0011" in result.output
+    assert "0023" not in result.output  # does not show other podcast episode data
 
 
 def test_mark_as_new_all_episodes_bulk_mode(runner):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,6 +211,13 @@ def test_ls_podcast_episodes(runner):
     assert "0001" not in result.output
 
 
+def test_ls_single_podcast_episode(runner):
+    result = runner.invoke(cli, ["ls", "-p", "greetings", "-e", "23"])
+    assert result.exit_code == 0
+    assert "0023" in result.output
+    assert "0011" not in result.output  # does not show other podcast episode data
+
+
 def test_mark_as_new_all_episodes_bulk_mode(runner):
     result = runner.invoke(cli, ["mark-as-new", "--force", "--bulk"])
     assert result.exit_code == 0


### PR DESCRIPTION
Extends the `ls` command to list data for only a single podcast episode.

Closes #114 