### PR TITLE
[115] Correct file type for encrypted store

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Any of the tagging commands can be used to remove tags (rather than apply them) 
 `pod-store` allows the user to override some default behavior by setting env vars:
 
     POD_STORE_PATH  # defaults to /home/<username>/.pod-store
-    POD_STORE_FILE_NAME  # defaults to "pod-store.json"
+    POD_STORE_FILE_NAME  # defaults to "pod-store.json" if not encrypted, "pod-store.gpg" if encrypted
     POD_STORE_PODCAST_DOWNLOAD_PATH  # defaults to /home/<username>/Podcasts
     POD_STORE_PODCAST_REFRESH_TIMEOUT  # seconds to wait before timing out a podcast RSS refresh. defaults to 15 seconds
     POD_STORE_EPISODE_DOWNLOAD_TIMEOUT  # seconds to wait before timing out an episode download. defaults to the value of `POD_STORE_PODCAST_REFRESH_TIMEOUT`

--- a/pod_store/__init__.py
+++ b/pod_store/__init__.py
@@ -32,9 +32,6 @@ DO_NOT_SET_EPISODE_METADATA = os.getenv("DO_NOT_SET_POD_STORE_EPISODE_METADATA",
 
 STORE_PATH = os.path.abspath(os.getenv("POD_STORE_PATH", DEFAULT_STORE_PATH))
 
-STORE_FILE_NAME = os.getenv("POD_STORE_FILE_NAME", "pod-store.json")
-STORE_FILE_PATH = os.path.join(STORE_PATH, STORE_FILE_NAME)
-
 GPG_ID_FILE_PATH = os.getenv(
     "POD_STORE_GPG_ID_FILE", os.path.join(STORE_PATH, ".gpg-id")
 )
@@ -43,6 +40,15 @@ try:
         GPG_ID = f.read()
 except FileNotFoundError:
     GPG_ID = None
+
+if GPG_ID:
+    DEFAULT_STORE_FILE_NAME = "pod-store.gpg"
+else:
+    DEFAULT_STORE_FILE_NAME = "pod-store.json"
+
+STORE_FILE_NAME = os.getenv("POD_STORE_FILE_NAME", DEFAULT_STORE_FILE_NAME)
+STORE_FILE_PATH = os.path.join(STORE_PATH, STORE_FILE_NAME)
+
 
 STORE_GIT_REPO = os.path.join(STORE_PATH, ".git")
 


### PR DESCRIPTION
Uses a `.gpg` file extension for encrypted store files.

Closes #115 