### PR TITLE
[082] Download episodes for podcasts with/without tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ To reactivate a podcast and resume updating it from RSS feed data regularly:
 
     pod set-active podcast-name
 
-Download all new episodes, or new episodes for just a specific podcast, or episodes with certain tags, or just a single episode:
+Download all new episodes, or new episodes for just a specific podcast, or episodes for podcasts with a certain tags, or episodes for podcasts without certain tags, or episodes with certain tags, or just a single episode:
 
     pod download
     pod download -p podcast-name
+    pod download -pt tag-name
+    pod download -up tag-name
     pod download -t tag-name
     pod download -p podcast-name -e episode-number
 

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -168,6 +168,13 @@ def add(ctx: click.Context, title: str, feed: str):
     help="Download episodes for podcasts that have been tagged. "
     "Multiple tags can be provided.",
 )
+@click.option(
+    "--podcast-untagged",
+    "-up",
+    multiple=True,
+    help="Download episodes for podcasts that have NOT been tagged. "
+    "Multiple tags can be provided.",
+)
 @catch_pod_store_errors
 @require_store
 @git_add_and_commit(
@@ -182,6 +189,7 @@ def download(
     tagged: Optional[List[str]],
     untagged: Optional[List[str]],
     podcast_tagged: Optional[List[str]],
+    podcast_untagged: Optional[List[str]],
 ):
     """Download podcast episodes. Use the command options to download all new episodes,
     only new episodes for a specific podcast, only episodes with specific tags, or only
@@ -209,6 +217,7 @@ def download(
         tagged=tagged,
         untagged=untagged,
         podcasts_tagged=podcast_tagged,
+        podcasts_untagged=podcast_untagged,
         **filters,
     )
 

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -161,6 +161,13 @@ def add(ctx: click.Context, title: str, feed: str):
     multiple=True,
     help="Download episodes that have NOT been tagged. Multiple tags can be provided.",
 )
+@click.option(
+    "--podcast-tagged",
+    "-pt",
+    multiple=True,
+    help="Download episodes for podcasts that have been tagged. "
+    "Multiple tags can be provided.",
+)
 @catch_pod_store_errors
 @require_store
 @git_add_and_commit(
@@ -174,6 +181,7 @@ def download(
     episode: Optional[int],
     tagged: Optional[List[str]],
     untagged: Optional[List[str]],
+    podcast_tagged: Optional[List[str]],
 ):
     """Download podcast episodes. Use the command options to download all new episodes,
     only new episodes for a specific podcast, only episodes with specific tags, or only
@@ -200,6 +208,7 @@ def download(
         podcast_title=podcast,
         tagged=tagged,
         untagged=untagged,
+        podcasts_tagged=podcast_tagged,
         **filters,
     )
 

--- a/pod_store/commands/filtering.py
+++ b/pod_store/commands/filtering.py
@@ -177,12 +177,13 @@ def get_filter_from_command_arguments(
     podcast_title: Optional[str] = None,
     tagged: Optional[List] = None,
     untagged: Optional[List] = None,
-    podcast_filters: Optional[dict] = None,
+    podcasts_tagged: Optional[list] = None,
     **filters,
 ) -> Union[EpisodeFilter, PodcastFilter]:
     """Helper method for building a filter based on common CLI command arguments."""
     tagged = tagged or []
     untagged = untagged or []
+    podcasts_tagged = podcasts_tagged or []
     if filter_for_episodes is None:
         filter_for_episodes = filter_for_episodes or podcast_title
 
@@ -191,6 +192,8 @@ def get_filter_from_command_arguments(
         **{u: False for u in untagged},
         **filters,
     }
+
+    podcast_filters = {**{pt: True for pt in podcasts_tagged}}
 
     if filter_for_episodes:
         filter_cls = EpisodeFilter

--- a/pod_store/commands/filtering.py
+++ b/pod_store/commands/filtering.py
@@ -178,12 +178,14 @@ def get_filter_from_command_arguments(
     tagged: Optional[List] = None,
     untagged: Optional[List] = None,
     podcasts_tagged: Optional[list] = None,
+    podcasts_untagged: Optional[list] = None,
     **filters,
 ) -> Union[EpisodeFilter, PodcastFilter]:
     """Helper method for building a filter based on common CLI command arguments."""
     tagged = tagged or []
     untagged = untagged or []
     podcasts_tagged = podcasts_tagged or []
+    podcasts_untagged = podcasts_untagged or []
     if filter_for_episodes is None:
         filter_for_episodes = filter_for_episodes or podcast_title
 
@@ -193,7 +195,10 @@ def get_filter_from_command_arguments(
         **filters,
     }
 
-    podcast_filters = {**{pt: True for pt in podcasts_tagged}}
+    podcast_filters = {
+        **{pt: True for pt in podcasts_tagged},
+        **{up: False for up in podcasts_untagged},
+    }
 
     if filter_for_episodes:
         filter_cls = EpisodeFilter

--- a/pod_store/commands/filtering.py
+++ b/pod_store/commands/filtering.py
@@ -31,11 +31,13 @@ class Filter(ABC):
         store: Store,
         new_episodes: bool = False,
         podcast_title: Optional[str] = None,
+        podcast_filters: Optional[dict] = None,
         **filters,
     ) -> None:
         self._store = store
         self._new_episodes = new_episodes
         self._podcast_title = podcast_title
+        self._extra_podcast_filters = podcast_filters or {}
         self._filters = filters
 
     @abstractproperty
@@ -66,7 +68,7 @@ class Filter(ABC):
             filters["has_new_episodes"] = True
         if self._podcast_title:
             filters["title"] = self._podcast_title
-        return filters
+        return {**filters, **self._extra_podcast_filters}
 
     def _passes_filters(self, obj: Union[Episode, Podcast], **filters) -> bool:
         """Checks whether a podcast/episode meets all the provided filter criteria."""
@@ -175,6 +177,7 @@ def get_filter_from_command_arguments(
     podcast_title: Optional[str] = None,
     tagged: Optional[List] = None,
     untagged: Optional[List] = None,
+    podcast_filters: Optional[dict] = None,
     **filters,
 ) -> Union[EpisodeFilter, PodcastFilter]:
     """Helper method for building a filter based on common CLI command arguments."""
@@ -195,5 +198,9 @@ def get_filter_from_command_arguments(
         filter_cls = PodcastFilter
 
     return filter_cls(
-        store=store, new_episodes=new_episodes, podcast_title=podcast_title, **filters
+        store=store,
+        new_episodes=new_episodes,
+        podcast_title=podcast_title,
+        podcast_filters=podcast_filters,
+        **filters,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,8 +17,12 @@ TEST_EPISODE_DOWNLOAD_PATH = os.path.join(
     TEST_PODCAST_EPISODE_DOWNLOADS_PATH, "0023-hello.mp3"
 )
 
-TEST_OTHER_EPISODE_DOWNLOAD_PATH = os.path.join(
-    TEST_PODCAST_DOWNLOADS_PATH, "farewell/0001-gone.mp3"
+OTHER_TEST_PODCAST_EPISODE_DOWNLOADS_PATH = os.path.join(
+    TEST_PODCAST_DOWNLOADS_PATH, "farewell"
+)
+
+OTHER_TEST_EPISODE_DOWNLOAD_PATH = os.path.join(
+    OTHER_TEST_PODCAST_EPISODE_DOWNLOADS_PATH, "0001-gone.mp3"
 )
 
 
@@ -41,9 +45,16 @@ def test_download_all_new_podcast_episodes(runner):
     result = runner.invoke(cli, ["download"])
     assert result.exit_code == 0
     assert result.output == (
-        f"Downloading: {TEST_OTHER_EPISODE_DOWNLOAD_PATH}.\n\n"
+        f"Downloading: {OTHER_TEST_EPISODE_DOWNLOAD_PATH}.\n\n"
         f"Downloading: {TEST_EPISODE_DOWNLOAD_PATH}.\n\n"
     )
+
+
+def test_download_episodes_for_podcasts_with_tag(runner):
+    result = runner.invoke(cli, ["download", "-pt", "hello"])
+    assert result.exit_code == 0
+    assert TEST_PODCAST_EPISODE_DOWNLOADS_PATH in result.output
+    assert OTHER_TEST_PODCAST_EPISODE_DOWNLOADS_PATH not in result.output
 
 
 def test_download_single_podcast_new_episodes(runner):
@@ -63,13 +74,13 @@ def test_download_single_episode(runner):
     assert result.output == f"Downloading: {download_path}.\n\n"
 
 
-def test_download_new_episodes_with_tag(runner):
+def test_download_episodes_with_tag(runner):
     result = runner.invoke(cli, ["download", "-t", "bar"])
     assert result.exit_code == 0
-    assert result.output == f"Downloading: {TEST_OTHER_EPISODE_DOWNLOAD_PATH}.\n\n"
+    assert result.output == f"Downloading: {OTHER_TEST_EPISODE_DOWNLOAD_PATH}.\n\n"
 
 
-def test_download_new_episodes_without_tag(runner):
+def test_download_episodes_without_tag(runner):
     result = runner.invoke(cli, ["download", "-u", "bar"])
     assert result.exit_code == 0
     assert result.output == f"Downloading: {TEST_EPISODE_DOWNLOAD_PATH}.\n\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,6 +57,13 @@ def test_download_episodes_for_podcasts_with_tag(runner):
     assert OTHER_TEST_PODCAST_EPISODE_DOWNLOADS_PATH not in result.output
 
 
+def test_download_episodes_for_podcasts_without_tag(runner):
+    result = runner.invoke(cli, ["download", "-up", "hello"])
+    assert result.exit_code == 0
+    assert OTHER_TEST_PODCAST_EPISODE_DOWNLOADS_PATH in result.output
+    assert TEST_PODCAST_EPISODE_DOWNLOADS_PATH not in result.output
+
+
 def test_download_single_podcast_new_episodes(runner):
     result = runner.invoke(cli, ["download", "-p", "greetings"])
     assert result.exit_code == 0

--- a/tests/test_command_filtering.py
+++ b/tests/test_command_filtering.py
@@ -39,6 +39,11 @@ def test_episode_filter_for_podcast(store):
     assert _get_episode_ids(filter.items) == ["aaa", "zzz"]
 
 
+def test_episode_filter_for_podcasts_with_extra_podcast_filters(store):
+    filter = EpisodeFilter(store=store, podcast_filters={"hello": True})
+    assert _get_episode_ids(filter.items) == ["aaa", "zzz"]
+
+
 def test_episode_filter_raises_exception_if_no_episodes_found(store):
     filter = EpisodeFilter(store=store, tags=["whoooo"])
     with pytest.raises(NoEpisodesFoundError):


### PR DESCRIPTION
Extends the `download` command to allow filtering for podcasts to download episodes for using tags.

Closes #82 