### PR TITLE
[120] BUGFIX: List episodes when `--podcast` option is specified in `ls` command

### DIFF
--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -400,7 +400,7 @@ def ls(
         new_episodes = False
         filters = {"episode_number": episode}
     else:
-        list_episodes = episodes
+        list_episodes = bool(episodes or podcast)
         new_episodes = new
         filters = {}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,7 +223,7 @@ def test_ls_without_tag(runner):
 
 
 def test_ls_podcast_episodes(runner):
-    result = runner.invoke(cli, ["ls", "--episodes", "-p", "greetings", "--all"])
+    result = runner.invoke(cli, ["ls", "-p", "greetings", "--all"])
     assert result.exit_code == 0
     assert "0023" in result.output
     assert "0001" not in result.output


### PR DESCRIPTION
Determine that the user wants to list episodes, rather than podcasts, when they have specified the `--podcast` option while using the `ls` command.

Closes #120 