### PR TITLE
[123] Remove excessive dashes in filenames

### DIFF
--- a/pod_store/episodes.py
+++ b/pod_store/episodes.py
@@ -183,10 +183,11 @@ class Episode:
         """
         lowercase_title = self.title.lower()
         cleaned_title = re.sub(r"[^a-zA-Z0-9]", "-", lowercase_title)
+        stripped_title = re.sub(r"(-{2,})", "-", cleaned_title)
         file_type = os.path.splitext(self.url)[1][:4]
         return os.path.join(
             self.podcast.episode_downloads_path,
-            f"{self.padded_episode_number}-{cleaned_title}{file_type}",
+            f"{self.padded_episode_number}-{stripped_title}{file_type}",
         )
 
     @property

--- a/tests/test_episodes.py
+++ b/tests/test_episodes.py
@@ -39,7 +39,7 @@ def test_episode_download_path_is_correct_path_for_filetype_without_invalid_char
         podcast=podcast,
         id="bbb",
         episode_number=981,
-        title="foo/bar: the fin?al[ RE:^ckONing",
+        title="foo/bar: the fin?al[ RE:^'ckONing",
         short_description="foo",
         long_description="foo (longer description)",
         url="http://foo.bar/bbb.ogg?jd289ds89xchw",
@@ -48,7 +48,7 @@ def test_episode_download_path_is_correct_path_for_filetype_without_invalid_char
     )
 
     assert episode.download_path == os.path.join(
-        TEST_PODCAST_EPISODE_DOWNLOADS_PATH, "0981-foo-bar--the-fin-al--re--ckoning.ogg"
+        TEST_PODCAST_EPISODE_DOWNLOADS_PATH, "0981-foo-bar-the-fin-al-re-ckoning.ogg"
     )
 
 


### PR DESCRIPTION
Replacing special characters in filenames with dashes can result in a lot of dashes appearing in a row.

Uses a regex to detect multiple dashes in a row. I don't know that this can easily be accomplished in a single regex since a lot of multiple dashes will be created by the initial regex pass.

Closes #123 