### PR TITLE
[125] Provide output from `git push` command

### DIFF
--- a/pod_store/util.py
+++ b/pod_store/util.py
@@ -50,7 +50,11 @@ def run_shell_command(cmd, cwd: Optional[str] = None) -> str:
     """
     try:
         proc = subprocess.run(cmd, cwd=cwd, capture_output=True, check=True, shell=True)
-        return proc.stdout.decode()
+        stdout = proc.stdout.decode()
+        if stdout:
+            return stdout
+        else:
+            return proc.stderr.decode()
     except subprocess.CalledProcessError as err:
         stderr = err.stderr.decode()
         raise ShellCommandError(f"{cmd}: {stderr}")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -58,6 +58,13 @@ def test_util_run_shell_command(mocked_subprocess_run):
     )
 
 
+def test_util_run_shell_command_returns_stderr_if_no_stdout(mocked_subprocess_run):
+    mocked_subprocess_run.configure_mock(
+        **{"return_value": fake_process(stdout=b"", stderr=b"output hidden")}
+    )
+    assert util.run_shell_command("hello world") == "output hidden"
+
+
 def test_util_run_shell_command_encounters_error(mocked_subprocess_run):
     mocked_subprocess_run.configure_mock(
         **{


### PR DESCRIPTION
Output from the `git push` command was not being provided when running e.g. `pod git push`.

This is because `git push` puts the relevant output onto the stderr stream, rather than the usual stdout.

Changes the implementation so that if a subprocess is run successfully and stdout is empty, the contents of stderr will be displayed to the user instead.

Closes #125 