### PR TITLE
[130] BUGFIX: `init` command does not use the correct file name for encrypted stores

### DIFF
--- a/pod_store/__init__.py
+++ b/pod_store/__init__.py
@@ -1,5 +1,7 @@
 """Encrypted CLI podcast tracker that syncs across devices. Inspired by `pass`."""
 import os
+from typing import Optional
+
 
 # The version is set automatically within the Github action for building a new
 # PyPI release: `pod_store./github/workflows/release.yml`
@@ -25,10 +27,19 @@ __license__ = "GPLv3+"
 __title__ = "pod-store"
 __version__ = version
 
-DEFAULT_STORE_PATH = os.path.join(os.path.expanduser("~"), ".pod-store")
+DEFAULT_ENCRYPTED_STORE_FILE_NAME = "pod-store.gpg"
+DEFAULT_UNENCRYPTED_STORE_FILE_NAME = "pod-store.json"
 DEFAULT_PODCAST_DOWNLOADS_PATH = os.path.join(os.path.expanduser("~"), "Podcasts")
+DEFAULT_TIMEOUT = 15
+DEFAULT_STORE_PATH = os.path.join(os.path.expanduser("~"), ".pod-store")
 
-DO_NOT_SET_EPISODE_METADATA = os.getenv("DO_NOT_SET_POD_STORE_EPISODE_METADATA", False)
+
+def get_default_store_file_name(gpg_id: Optional[str]) -> str:
+    if gpg_id:
+        return DEFAULT_ENCRYPTED_STORE_FILE_NAME
+    else:
+        return DEFAULT_UNENCRYPTED_STORE_FILE_NAME
+
 
 STORE_PATH = os.path.abspath(os.getenv("POD_STORE_PATH", DEFAULT_STORE_PATH))
 
@@ -41,24 +52,21 @@ try:
 except FileNotFoundError:
     GPG_ID = None
 
-if GPG_ID:
-    DEFAULT_STORE_FILE_NAME = "pod-store.gpg"
-else:
-    DEFAULT_STORE_FILE_NAME = "pod-store.json"
-
-STORE_FILE_NAME = os.getenv("POD_STORE_FILE_NAME", DEFAULT_STORE_FILE_NAME)
+STORE_FILE_NAME = os.getenv("POD_STORE_FILE_NAME", get_default_store_file_name(GPG_ID))
 STORE_FILE_PATH = os.path.join(STORE_PATH, STORE_FILE_NAME)
-
-
 STORE_GIT_REPO = os.path.join(STORE_PATH, ".git")
 
+
+DO_NOT_SET_EPISODE_METADATA = os.getenv("DO_NOT_SET_POD_STORE_EPISODE_METADATA", False)
+EPISODE_DOWNLOAD_TIMEOUT = float(
+    os.getenv("POD_STORE_EPISODE_DOWNLOAD_TIMEOUT", DEFAULT_TIMEOUT)
+)
 
 PODCAST_DOWNLOADS_PATH = os.path.abspath(
     os.getenv("POD_STORE_PODCAST_DOWNLOADS_PATH", DEFAULT_PODCAST_DOWNLOADS_PATH)
 )
-PODCAST_REFRESH_TIMEOUT = float(os.getenv("POD_STORE_PODCAST_REFRESH_TIMEOUT", 15))
-EPISODE_DOWNLOAD_TIMEOUT = float(
-    os.getenv("POD_STORE_EPISODE_DOWNLOAD_TIMEOUT", PODCAST_REFRESH_TIMEOUT)
+PODCAST_REFRESH_TIMEOUT = float(
+    os.getenv("POD_STORE_PODCAST_REFRESH_TIMEOUT", DEFAULT_TIMEOUT)
 )
 
 SECURE_GIT_MODE = os.getenv("POD_STORE_SECURE_GIT_MODE", False)

--- a/pod_store/__init__.py
+++ b/pod_store/__init__.py
@@ -2,7 +2,6 @@
 import os
 from typing import Optional
 
-
 # The version is set automatically within the Github action for building a new
 # PyPI release: `pod_store./github/workflows/release.yml`
 #

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -5,7 +5,13 @@ from typing import Any, List, Optional
 import click
 import requests
 
-from . import GPG_ID, PODCAST_DOWNLOADS_PATH, STORE_FILE_PATH, STORE_PATH
+from . import (
+    DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
+    GPG_ID,
+    PODCAST_DOWNLOADS_PATH,
+    STORE_FILE_PATH,
+    STORE_PATH,
+)
 from .commands.commit_messages import (
     download_commit_message_builder,
     refresh_commit_message_builder,
@@ -308,7 +314,7 @@ def init(git: bool, git_url: Optional[str], gpg_id: Optional[str]):
 
     Store.init(
         store_path=STORE_PATH,
-        store_file_path=STORE_FILE_PATH,
+        store_file_name=DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
         setup_git=git,
         git_url=git_url,
         gpg_id=gpg_id,

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -6,11 +6,11 @@ import click
 import requests
 
 from . import (
-    DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
     GPG_ID,
     PODCAST_DOWNLOADS_PATH,
     STORE_FILE_PATH,
     STORE_PATH,
+    get_default_store_file_name,
 )
 from .commands.commit_messages import (
     download_commit_message_builder,
@@ -312,15 +312,20 @@ def init(git: bool, git_url: Optional[str], gpg_id: Optional[str]):
     if git_url:
         click.echo("Please note, this could take a minute or two...")
 
+    store_file_name = os.getenv(
+        "POD_STORE_FILE_NAME", get_default_store_file_name(gpg_id)
+    )
+
     Store.init(
         store_path=STORE_PATH,
-        store_file_name=DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
+        store_file_name=store_file_name,
         setup_git=git,
         git_url=git_url,
         gpg_id=gpg_id,
     )
 
-    click.echo(f"Store created: {STORE_PATH}")
+    store_file_path = os.path.join(STORE_PATH, store_file_name)
+    click.echo(f"Store created: {store_file_path}")
     click.echo(f"Podcast episodes will be downloaded to {PODCAST_DOWNLOADS_PATH}")
 
     if git:

--- a/pod_store/store.py
+++ b/pod_store/store.py
@@ -130,7 +130,7 @@ class Store:
     def init(
         cls,
         store_path: str,
-        store_file_path: str,
+        store_file_name: str,
         setup_git: bool,
         git_url: Optional[str] = None,
         gpg_id: Optional[str] = None,
@@ -156,6 +156,7 @@ class Store:
             with open(os.path.join(store_path, ".gitignore"), "w") as f:
                 f.write(".gpg-id")
 
+        store_file_path = os.path.join(store_path, store_file_name)
         if gpg_id:
             cls._setup_encrypted_store(gpg_id=gpg_id, store_file_path=store_file_path)
         else:

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 env =
     POD_STORE_PATH=tests/pod-store
     POD_STORE_PODCAST_DOWNLOADS_PATH=tests/pod-store-downloads
+    POD_STORE_SECURE_GIT_MODE=
+    POD_STORE_EXTREME_SECURE_GIT_MODE=

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,12 +4,14 @@ import pytest
 import requests
 from click.testing import CliRunner
 
+from pod_store import DEFAULT_ENCRYPTED_STORE_FILE_NAME
 from pod_store.__main__ import cli
 
 from . import (
     TEST_GPG_ID_FILE_PATH,
     TEST_PODCAST_DOWNLOADS_PATH,
     TEST_PODCAST_EPISODE_DOWNLOADS_PATH,
+    TEST_STORE_FILE_PATH,
     TEST_STORE_PATH,
 )
 
@@ -127,7 +129,7 @@ def test_init(start_with_no_store, runner):
     result = runner.invoke(cli, ["init", "--no-git"])
     assert result.exit_code == 0
     assert result.output == (
-        f"Store created: {TEST_STORE_PATH}\n"
+        f"Store created: {TEST_STORE_FILE_PATH}\n"
         f"Podcast episodes will be downloaded to {TEST_PODCAST_DOWNLOADS_PATH}\n"
     )
 
@@ -151,8 +153,12 @@ def test_init_with_git_url(start_with_no_store, runner):
 
 
 def test_init_with_gpg_id(start_with_no_store, runner):
+    encrypted_store_file_path = os.path.join(
+        TEST_STORE_PATH, DEFAULT_ENCRYPTED_STORE_FILE_NAME
+    )
     result = runner.invoke(cli, ["init", "--no-git", "-g", "foo@bar.com"])
     assert result.exit_code == 0
+    assert encrypted_store_file_path in result.output
     assert result.output.endswith("GPG ID set for store encryption.\n")
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -3,6 +3,10 @@ import os
 
 import pytest
 
+from pod_store import (
+    DEFAULT_ENCRYPTED_STORE_FILE_NAME,
+    DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
+)
 from pod_store.exc import StoreExistsError, StoreIsNotEncrypted
 from pod_store.store import Store
 from pod_store.store_file_handlers import EncryptedStoreFileHandler
@@ -21,18 +25,9 @@ def test_init_store_creates_store_directory_and_store_file_and_downloads_path(
     Store.init(
         setup_git=False,
         store_path=TEST_STORE_PATH,
-        store_file_path=TEST_STORE_FILE_PATH,
+        store_file_name=DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
     )
     assert os.path.exists(TEST_STORE_FILE_PATH)
-
-
-def test_init_store_already_exists():
-    with pytest.raises(StoreExistsError):
-        Store.init(
-            setup_git=False,
-            store_path=TEST_STORE_PATH,
-            store_file_path=TEST_STORE_FILE_PATH,
-        )
 
 
 def test_init_store_setup_git_initializes_git_repo_and_sets_gitignore(
@@ -41,7 +36,7 @@ def test_init_store_setup_git_initializes_git_repo_and_sets_gitignore(
     Store.init(
         setup_git=True,
         store_path=TEST_STORE_PATH,
-        store_file_path=TEST_STORE_FILE_PATH,
+        store_file_name=DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
     )
     with open(os.path.join(TEST_STORE_PATH, ".gitignore")) as f:
         assert f.read() == ".gpg-id"
@@ -56,7 +51,7 @@ def test_init_store_setup_git_with_git_url_clones_remote_repo(
         setup_git=True,
         git_url="https://git.foo.bar/pod-store.git",
         store_path=TEST_STORE_PATH,
-        store_file_path=TEST_STORE_FILE_PATH,
+        store_file_name=DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
     )
     mocked_run_shell_command.assert_called_with(
         f"git clone https://git.foo.bar/pod-store.git {TEST_STORE_PATH}"
@@ -74,7 +69,7 @@ def test_init_store_setup_git_with_git_url_and_gpg_id_creates_gpg_id_file(
         setup_git=True,
         git_url="https://git.foo.bar/pod-store.git",
         store_path=TEST_STORE_PATH,
-        store_file_path=TEST_STORE_FILE_PATH,
+        store_file_name=DEFAULT_ENCRYPTED_STORE_FILE_NAME,
         gpg_id="foo@bar.com",
     )
     mocked_run_shell_command.assert_called_with(
@@ -91,11 +86,20 @@ def test_init_store_with_gpg_id_sets_gpg_id_file_and_creates_encrypted_store_fil
         gpg_id="hello@world.com",
         setup_git=False,
         store_path=TEST_STORE_PATH,
-        store_file_path=TEST_STORE_FILE_PATH,
+        store_file_name=DEFAULT_ENCRYPTED_STORE_FILE_NAME,
     )
 
     with open(os.path.join(TEST_STORE_PATH, ".gpg-id")) as f:
         assert f.read() == "hello@world.com"
+
+
+def test_init_store_already_exists():
+    with pytest.raises(StoreExistsError):
+        Store.init(
+            setup_git=False,
+            store_path=TEST_STORE_PATH,
+            store_file_name=DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
+        )
 
 
 def test_store_encrypt_reads_existing_store_data_and_sets_up_encrypted_store_and_file(
@@ -124,7 +128,7 @@ def test_unencrypt_reads_existing_store_data_and_writes_unencrypted_store_file(
 ):
     Store.init(
         store_path=TEST_STORE_PATH,
-        store_file_path=TEST_STORE_FILE_PATH,
+        store_file_name=DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
         setup_git=False,
         gpg_id="oof@rab.com",
     )


### PR DESCRIPTION
Passing in a GPG key for encryption resulted in the `pod init` command creating a store with the default unencrypted file name (`pod-store.json`). That is because the store file path was being set at load time for the `pod_store` module, based on whether a store existed with a GPG ID already set.

This breaks out the logic for determining the default store file name into a function that can be reused in the `init` command. The logic for creating the store file path is broken up in the `pod_store.Store.init` method: now a file name is passed for the store (instead of a whole file path), and the the store class builds and passes on the full file path.

Closes #130 