### PR TITLE
[129] BUGFIX: `init` command deals with cloning from empty remote repo

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -243,3 +243,23 @@ def tagger():
 @pytest.fixture
 def start_with_no_store():
     shutil.rmtree(TEST_STORE_PATH)
+
+
+@pytest.fixture
+def mocked_git_clone_with_empty_repo(mocker):
+    return mocker.patch(
+        "pod_store.store.run_shell_command",
+        side_effect=lambda _: os.makedirs(TEST_STORE_PATH),
+    )
+
+
+@pytest.fixture
+def mocked_git_clone_with_store_file(mocker):
+    def _create_store_file(*args, **kwargs):
+        os.makedirs(TEST_STORE_PATH)
+        with open(TEST_STORE_FILE_PATH, "w") as f:
+            f.write("")
+
+    return mocker.patch(
+        "pod_store.store.run_shell_command", side_effect=_create_store_file
+    )

--- a/pod_store/store.py
+++ b/pod_store/store.py
@@ -143,6 +143,7 @@ class Store:
         as an encrypted file.
         """
         store_file_path = os.path.join(store_path, store_file_name)
+        gitignore_file_path = os.path.join(store_path, ".gitignore")
 
         os.makedirs(PODCAST_DOWNLOADS_PATH, exist_ok=True)
 
@@ -157,8 +158,8 @@ class Store:
             if setup_git:
                 run_git_command("init")
 
-        with open(os.path.join(store_path, ".gitignore"), "w") as f:
-            f.write(".gpg-id")
+                with open(gitignore_file_path, "w") as f:
+                    f.write(".gpg-id")
 
         if gpg_id:
             cls._setup_encrypted_store(gpg_id=gpg_id, store_file_path=store_file_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,7 +143,14 @@ def test_init_with_git(start_with_no_store, runner):
     )
 
 
-def test_init_with_git_url(start_with_no_store, runner):
+def test_init_with_git_url(
+    mocked_git_clone_with_store_file, start_with_no_store, runner
+):
+    def _create_store_file(*args, **kwargs):
+        os.makedirs(TEST_STORE_PATH)
+        with open(TEST_STORE_FILE_PATH, "w") as f:
+            f.write("")
+
     result = runner.invoke(cli, ["init", "-u", "https://git.foo.bar/pod-store.git"])
     assert result.exit_code == 0
     assert "take a minute" in result.output

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -44,27 +44,38 @@ def test_init_store_setup_git_initializes_git_repo_and_sets_gitignore(
 
 
 def test_init_store_setup_git_with_git_url_clones_remote_repo(
-    start_with_no_store, mocker
+    mocked_git_clone_with_store_file, start_with_no_store
 ):
-    mocked_run_shell_command = mocker.patch("pod_store.store.run_shell_command")
     Store.init(
         setup_git=True,
         git_url="https://git.foo.bar/pod-store.git",
         store_path=TEST_STORE_PATH,
         store_file_name=DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
     )
-    mocked_run_shell_command.assert_called_with(
+    mocked_git_clone_with_store_file.assert_called_with(
         f"git clone https://git.foo.bar/pod-store.git {TEST_STORE_PATH}"
     )
+    assert os.path.exists(TEST_STORE_FILE_PATH)
+
+
+def test_init_store_setup_git_with_git_url_will_create_store_file_if_repo_is_empty(
+    mocked_git_clone_with_empty_repo, start_with_no_store
+):
+    Store.init(
+        setup_git=True,
+        git_url="https://git.foo.bar/pod-store.git",
+        store_path=TEST_STORE_PATH,
+        store_file_name=DEFAULT_UNENCRYPTED_STORE_FILE_NAME,
+    )
+    mocked_git_clone_with_empty_repo.assert_called_with(
+        f"git clone https://git.foo.bar/pod-store.git {TEST_STORE_PATH}"
+    )
+    assert os.path.exists(TEST_STORE_FILE_PATH)
 
 
 def test_init_store_setup_git_with_git_url_and_gpg_id_creates_gpg_id_file(
-    start_with_no_store, mocker
+    mocked_git_clone_with_empty_repo, start_with_no_store
 ):
-    mocked_run_shell_command = mocker.patch(
-        "pod_store.store.run_shell_command",
-        side_effect=lambda _: os.makedirs(TEST_STORE_PATH),
-    )
     Store.init(
         setup_git=True,
         git_url="https://git.foo.bar/pod-store.git",
@@ -72,7 +83,7 @@ def test_init_store_setup_git_with_git_url_and_gpg_id_creates_gpg_id_file(
         store_file_name=DEFAULT_ENCRYPTED_STORE_FILE_NAME,
         gpg_id="foo@bar.com",
     )
-    mocked_run_shell_command.assert_called_with(
+    mocked_git_clone_with_empty_repo.assert_called_with(
         f"git clone https://git.foo.bar/pod-store.git {TEST_STORE_PATH}",
     )
     with open(TEST_GPG_ID_FILE_PATH) as f:


### PR DESCRIPTION
Setting up a pod store with a remote repo:

    pod init -u foo@bar.com:pod/pods.git

Failed to create a new store file if the repo did not have one set up yet.

When cloning from a remote repo, this creates a new store file if one does not already exist.

Closes #129 