### PR TITLE
[133] BUGFIX: Unencrypting or encrypting store leaves orphaned files

### DIFF
--- a/pod_store/__init__.py
+++ b/pod_store/__init__.py
@@ -33,7 +33,15 @@ DEFAULT_TIMEOUT = 15
 DEFAULT_STORE_PATH = os.path.join(os.path.expanduser("~"), ".pod-store")
 
 
-def get_default_store_file_name(gpg_id: Optional[str]) -> str:
+def get_store_file_path(
+    store_file_name: Optional[str] = None,
+    gpg_id: Optional[str] = None,
+) -> str:
+    store_file_name = store_file_name or get_default_store_file_name(gpg_id)
+    return os.path.join(STORE_PATH, store_file_name)
+
+
+def get_default_store_file_name(gpg_id: Optional[str] = None) -> str:
     if gpg_id:
         return DEFAULT_ENCRYPTED_STORE_FILE_NAME
     else:
@@ -52,7 +60,7 @@ except FileNotFoundError:
     GPG_ID = None
 
 STORE_FILE_NAME = os.getenv("POD_STORE_FILE_NAME", get_default_store_file_name(GPG_ID))
-STORE_FILE_PATH = os.path.join(STORE_PATH, STORE_FILE_NAME)
+STORE_FILE_PATH = get_store_file_path(store_file_name=STORE_FILE_NAME, gpg_id=GPG_ID)
 STORE_GIT_REPO = os.path.join(STORE_PATH, ".git")
 
 

--- a/pod_store/store.py
+++ b/pod_store/store.py
@@ -8,7 +8,7 @@ Reading/writing to the store file is delegated to the classes in the
 import os
 from typing import List, Optional
 
-from . import GPG_ID_FILE_PATH, PODCAST_DOWNLOADS_PATH
+from . import GPG_ID_FILE_PATH, PODCAST_DOWNLOADS_PATH, get_store_file_path
 from .exc import (
     PodcastDoesNotExistError,
     PodcastExistsError,
@@ -188,16 +188,16 @@ class Store:
         """
         if not os.path.exists(GPG_ID_FILE_PATH):
             raise StoreIsNotEncrypted(GPG_ID_FILE_PATH)
-        store_file_path = self._file_handler.store_file_path
+        existing_store_file_path = self._file_handler.store_file_path
         store_data = self._file_handler.read_data()
-        unencrypted_store_file_path = "{basename}.json".format(
-            basename=os.path.splitext(store_file_path)[0]
-        )
+        unencrypted_store_file_path = get_store_file_path(gpg_id=None)
         self._setup_unencrypted_store(
             store_file_path=unencrypted_store_file_path,
             store_data=store_data,
             overwrite_existing=True,
         )
+        if existing_store_file_path != unencrypted_store_file_path:
+            os.remove(existing_store_file_path)
 
     def save(self) -> None:
         """Save data to the store json file."""

--- a/pod_store/store.py
+++ b/pod_store/store.py
@@ -171,14 +171,17 @@ class Store:
 
     def encrypt(self, gpg_id: str) -> None:
         """Encrypt an existing store that is currently stored in plaintext."""
-        store_file_path = self._file_handler.store_file_path
+        existing_store_file_path = self._file_handler.store_file_path
         store_data = self._file_handler.read_data()
+        encrypted_store_file_path = get_store_file_path(gpg_id=gpg_id)
         self._setup_encrypted_store(
             gpg_id=gpg_id,
-            store_file_path=store_file_path,
+            store_file_path=encrypted_store_file_path,
             store_data=store_data,
             overwrite_existing=True,
         )
+        if encrypted_store_file_path != existing_store_file_path:
+            os.remove(existing_store_file_path)
 
     def unencrypt(self) -> None:
         """Unencrypt an existing store that is currently stored as encrypted data.


### PR DESCRIPTION
Encrypting a store will leave behind the old unencrypted store file (e.g. `pod-store.json`). Same in reverse with unencrypting a store.

Deletes these files.

Closes #133 