### PR TITLE
Apply bulk tagging changes even if aborted

### DIFF
--- a/tests/test_command_tagging.py
+++ b/tests/test_command_tagging.py
@@ -9,6 +9,7 @@ from pod_store.commands.tagging import (
     TAG_PODCASTS_INTERACTIVE_MODE_PROMPT_MESSAGE_TEMPLATE,
     TAGGED_EPISODE_MESSAGE_TEMPLATE,
     TAGGED_PODCAST_MESSAGE_TEMPLATE,
+    StopBulkTagging,
     Tagger,
     TaggerPresenter,
     apply_tags,
@@ -185,10 +186,9 @@ def test_tagger_interactive_mode_quits_when_prompted(mocker, store, tagger):
         "pod_store.commands.tagging.click.prompt", return_value="q"
     )
 
-    with pytest.raises(click.Abort):
-        assert list(tagger.tag_items(interactive_mode=True)) == [
-            "Choose the podcasts.",
-        ]
+    assert list(tagger.tag_items(interactive_mode=True)) == [
+        "Choose the podcasts.",
+    ]
 
     # verify the prompt is called by checking the last call
     mocked_click_prompt.assert_called_with(
@@ -228,8 +228,6 @@ def test_tagger_interactive_mode_displays_help_message_when_prompted(
     mocker.patch("pod_store.commands.tagging.click.prompt", side_effect=["h", "q"])
     mocked_click_echo = mocker.patch("pod_store.commands.tagging.click.echo")
 
-    # catch the exception raised when quitting after first help message
-    with pytest.raises(click.Abort):
-        list(tagger.tag_items(interactive_mode=True))
+    list(tagger.tag_items(interactive_mode=True))
 
     mocked_click_echo.assert_called_with("Choose the podcasts.")

--- a/tests/test_command_tagging.py
+++ b/tests/test_command_tagging.py
@@ -1,4 +1,3 @@
-import click
 import pytest
 
 from pod_store.commands.filtering import EpisodeFilter, PodcastFilter
@@ -9,7 +8,6 @@ from pod_store.commands.tagging import (
     TAG_PODCASTS_INTERACTIVE_MODE_PROMPT_MESSAGE_TEMPLATE,
     TAGGED_EPISODE_MESSAGE_TEMPLATE,
     TAGGED_PODCAST_MESSAGE_TEMPLATE,
-    StopBulkTagging,
     Tagger,
     TaggerPresenter,
     apply_tags,


### PR DESCRIPTION
Interactive bulk tagging enables the user to quit in the middle. These changes were not being applied because the `click.Abort` exception is raised in that case, bypassing the command decorators that persist changes to disk/git. 