### PR TITLE
Reverse item order for tagging operations

### DIFF
--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -431,6 +431,7 @@ def ls(
     help="(flag): Run this command in interactive mode to select which episodes to "
     "mark, or bulk mode to mark all episodes. Defaults to `--interactive`.",
 )
+@click.option("-r", "--reverse", is_flag=True, help="Reverse order of items.")
 @click.option(
     "-f",
     "--force",
@@ -451,6 +452,7 @@ def mark_as_new(
     ctx: click.Context,
     podcast: Optional[str],
     interactive: bool,
+    reverse: bool,
     force: Optional[bool],
 ):
     """Add the `new` tag to a group of episodes."""
@@ -463,7 +465,7 @@ def mark_as_new(
         action="mark",
     )
 
-    for msg in tagger.tag_items(interactive_mode=interactive):
+    for msg in tagger.tag_items(interactive_mode=interactive, reverse_order=reverse):
         click.echo(msg)
 
 
@@ -481,6 +483,7 @@ def mark_as_new(
     help="(flag): Run this command in interactive mode to select which episodes to "
     "mark, or bulk mode to mark all episodes. Defaults to `--interactive`.",
 )
+@click.option("-r", "--reverse", is_flag=True, help="Reverse order of items.")
 @click.option(
     "-f",
     "--force",
@@ -501,6 +504,7 @@ def mark_as_old(
     ctx: click.Context,
     podcast: Optional[str],
     interactive: bool,
+    reverse: bool,
     force: Optional[bool],
 ):
     """Remove the `new` tag from a group of episodes."""
@@ -514,7 +518,7 @@ def mark_as_old(
         action="unmark",
     )
 
-    for msg in tagger.tag_items(interactive_mode=interactive):
+    for msg in tagger.tag_items(interactive_mode=interactive, reverse_order=reverse):
         click.echo(msg)
 
 
@@ -695,6 +699,7 @@ def set_inactive(ctx: click.Context, podcast: str):
     default=True,
     help="Interactively determine which items to tag, or apply the tag to all items.",
 )
+@click.option("-r", "--reverse", is_flag=True, help="Reverse order of items.")
 @click.option(
     "-f",
     "--force",
@@ -719,6 +724,7 @@ def tag(
     episode: Optional[int],
     episodes: bool,
     interactive: bool,
+    reverse: bool,
     force: bool,
 ):
     """Tag (or untag) podcasts or episodes with arbitrary tags.
@@ -748,7 +754,7 @@ def tag(
         episode_number=episode,
         is_untagger=untag,
     )
-    for msg in tagger.tag_items(interactive_mode=interactive):
+    for msg in tagger.tag_items(interactive_mode=interactive, reverse_order=reverse):
         click.echo(msg)
 
 

--- a/pod_store/commands/tagging.py
+++ b/pod_store/commands/tagging.py
@@ -285,17 +285,25 @@ class Tagger:
             tagging_action=tagging_action,
         )
 
-    def tag_items(self, interactive_mode: bool = False):
+    def tag_items(self, interactive_mode: bool = False, reverse_order: bool = False):
         """Perform the tagging action on the collection of items.
 
         If the `intercative_mode` flag is set, the user will be prompted interactively
         to choose which items to tag or untag.
+
+        If the `reverse_order` flag is set, the order of items returned by the filter
+        will be reversed.
         """
         if interactive_mode:
             yield self._presenter.interactive_mode_help_message_template.format(
                 presenter=self._presenter
             )
-        for item in self._pod_store_filter.items:
+
+        items = self._pod_store_filter.items
+        if reverse_order:
+            items = list(reversed(items))
+
+        for item in items:
             try:
                 if interactive_mode:
                     interactive_mode, msg = self._handle_item_interactively(item)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -258,6 +258,12 @@ def test_mark_as_new_all_episodes_bulk_mode(runner):
     assert "Marked as new: greetings" in result.output
 
 
+def test_mark_as_new_reverse_order(runner):
+    result = runner.invoke(cli, ["mark-as-new", "--reverse", "--force", "--bulk"])
+    assert result.exit_code == 0
+    assert result.output.index("greetings") < result.output.index("farewell")
+
+
 def test_mark_as_new_for_single_podcast(runner):
     result = runner.invoke(cli, ["mark-as-new", "--force", "--bulk", "-p", "farewell"])
     assert result.exit_code == 0
@@ -278,6 +284,12 @@ def test_mark_as_old_all_episodes_bulk_mode(runner):
     assert result.exit_code == 0
     assert "Unmarked as new: farewell" in result.output
     assert "Unmarked as new: greetings" in result.output
+
+
+def test_mark_as_old_reverse_order(runner):
+    result = runner.invoke(cli, ["mark-as-old", "--reverse", "--force", "--bulk"])
+    assert result.exit_code == 0
+    assert result.output.index("greetings") < result.output.index("farewell")
 
 
 def test_mark_as_old_for_single_podcast(runner):
@@ -355,6 +367,12 @@ def test_tag_all_episodes_bulk_mode(runner):
     assert result.exit_code == 0
     assert "Tagged as foo: farewell" in result.output
     assert "Tagged as foo: greetings" in result.output
+
+
+def test_tag_reverse_order(runner):
+    result = runner.invoke(cli, ["tag", "-t", "foo", "--reverse", "--force", "--bulk"])
+    assert result.exit_code == 0
+    assert result.output.index("greetings") < result.output.index("farewell")
 
 
 def test_tag_episodes_for_single_podcast(runner):

--- a/tests/test_command_tagging.py
+++ b/tests/test_command_tagging.py
@@ -116,6 +116,13 @@ def test_tagger_applies_tags_to_filter_items_and_returns_formatted_messages(
     assert "foo" in store.podcasts.get("greetings").tags
 
 
+def test_tagger_reverses_order_of_items_when_prompted(store, tagger):
+    assert list(tagger.tag_items(reverse_order=True)) == [
+        "Choosing the following tag(s) for greetings: foo.",
+        "Choosing the following tag(s) for farewell: foo.",
+    ]
+
+
 def test_untagger_removes_tags_from_filter_items_and_returns_formatted_messages(store):
     pod_store_filter = EpisodeFilter(store=store, foo=True)
     presenter = TaggerPresenter(


### PR DESCRIPTION
Allows tagging items in reverse order (older items first).