### PR TITLE
BUGFIX: `refresh` command blows up on connection errors

### DIFF
--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -227,8 +227,8 @@ def download(
                 with click.progressbar(download, length=download.length) as bar:
                     for _ in bar:
                         pass
-        except requests.ConnectTimeout:
-            click.secho("Error: timed out when downloading episode.", fg="red")
+        except requests.exceptions.ConnectionError as err:
+            click.secho(f"Error when downloading episode: {err}", fg="red")
 
 
 @cli.command()
@@ -653,8 +653,8 @@ def refresh(
         click.echo(f"Refreshing {podcast.title}.")
         try:
             podcast.refresh()
-        except requests.ConnectTimeout:
-            click.secho("Error: timed out when reading RSS feed.", fg="red")
+        except requests.exceptions.ConnectionError as err:
+            click.secho(f"Error when updating RSS feed: {err}", fg="red")
 
 
 @cli.command()

--- a/pod_store/podcasts.py
+++ b/pod_store/podcasts.py
@@ -207,10 +207,13 @@ class Podcast:
 
             episodes_seen.append(episode_data["id"])
 
-        # clean up old episodes no longer present in the feed
+        # Clean up old episodes no longer present in the feed
         for episode in self.episodes.list():
             if episode.id not in episodes_seen:
                 self.episodes.delete(episode.id)
+
+        # Register that the podcast's data has been updated.
+        self.updated_at = datetime.utcnow()
 
     def tag(self, tag_name: str) -> None:
         """Apply a tag to the podcast."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,7 +98,7 @@ def test_download_episodes_without_tag(runner):
 def test_download_times_out(timed_out_request, runner):
     result = runner.invoke(cli, ["download", "-p", "greetings"])
     assert result.exit_code == 0
-    assert "timed out" in result.output
+    assert "error" in result.output.lower()
 
 
 def test_encrypt_store(runner):
@@ -381,7 +381,7 @@ def test_refresh_podcasts_without_tag(runner):
 def test_refresh_podcast_times_out(timed_out_request, runner):
     result = runner.invoke(cli, ["refresh", "-p", "greetings"])
     assert result.exit_code == 0
-    assert "timed out" in result.output
+    assert "error" in result.output.lower()
 
 
 def test_rm(runner):


### PR DESCRIPTION
Wider exception handling catches more errors without blowing up the whole process. This applies to the `refresh` and `download` commands.