### PR TITLE
Catch all errors when refreshing or downloading podcasts

### DIFF
--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -3,7 +3,6 @@ import os
 from typing import Any, List, Optional
 
 import click
-import requests
 
 from . import (
     GPG_ID,
@@ -227,7 +226,7 @@ def download(
                 with click.progressbar(download, length=download.length) as bar:
                     for _ in bar:
                         pass
-        except requests.exceptions.ConnectionError as err:
+        except Exception as err:
             click.secho(f"Error when downloading episode: {err}", fg="red")
 
 

--- a/pod_store/__main__.py
+++ b/pod_store/__main__.py
@@ -653,7 +653,7 @@ def refresh(
         click.echo(f"Refreshing {podcast.title}.")
         try:
             podcast.refresh()
-        except requests.exceptions.ConnectionError as err:
+        except Exception as err:
             click.secho(f"Error when updating RSS feed: {err}", fg="red")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,7 +95,7 @@ def test_download_episodes_without_tag(runner):
     assert result.output == f"Downloading: {TEST_EPISODE_DOWNLOAD_PATH}.\n\n"
 
 
-def test_download_times_out(timed_out_request, runner):
+def test_download_encounters_error(timed_out_request, runner):
     result = runner.invoke(cli, ["download", "-p", "greetings"])
     assert result.exit_code == 0
     assert "error" in result.output.lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -378,7 +378,7 @@ def test_refresh_podcasts_without_tag(runner):
     assert result.output == "Refreshing farewell.\n"
 
 
-def test_refresh_podcast_times_out(timed_out_request, runner):
+def test_refresh_podcast_encounters_error(timed_out_request, runner):
     result = runner.invoke(cli, ["refresh", "-p", "greetings"])
     assert result.exit_code == 0
     assert "error" in result.output.lower()


### PR DESCRIPTION
The previous error-checking was too restrictive. Better to catch all exceptions that are encountered when refreshing or downloading a podcast.